### PR TITLE
feat(*): Add Chat Models API, User Functions API, and Collection Util…

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,29 @@ results, err := client.Find("users", query)
 
 - `ListCollections() ([]string, error)`
 - `DeleteCollection(collection string) error`
+- `CollectionExists(collection string) (bool, error)` - Check if collection
+  exists
+- `CountDocuments(collection string) (int64, error)` - Count documents in
+  collection
+
+### Chat Models
+
+- `GetChatModels() (map[string][]string, error)` - Get all available chat models
+  by provider
+- `GetChatModel(provider string) ([]string, error)` - Get models for a specific
+  provider
+
+### User Functions
+
+- `SaveUserFunction(userFunction UserFunction) (string, error)` - Create a new
+  user function
+- `GetUserFunction(label string) (*UserFunction, error)` - Get user function by
+  label
+- `ListUserFunctions(tags []string) ([]UserFunction, error)` - List all user
+  functions (optionally filter by tags)
+- `UpdateUserFunction(label string, userFunction UserFunction) error` - Update
+  existing user function
+- `DeleteUserFunction(label string) error` - Delete user function
 
 ### WebSocket Methods
 
@@ -380,6 +403,13 @@ direct API):
   Chat with sessions
 - **[client_chat_advanced.go](https://github.com/ekoDB/ekodb-client/blob/main/examples/go/client_chat_advanced.go)** -
   Advanced chat features
+
+### Additional APIs
+
+- **[client_chat_models.go](https://github.com/ekoDB/ekodb-client/blob/main/examples/go/client_chat_models.go)** -
+  Chat models API
+- **[client_user_functions.go](https://github.com/ekoDB/ekodb-client/blob/main/examples/go/client_user_functions.go)** -
+  User functions API
 
 ### Running Examples
 

--- a/README.md
+++ b/README.md
@@ -322,12 +322,12 @@ results, err := client.Find("users", query)
 - `DeleteCollection(collection string) error`
 - `CollectionExists(collection string) (bool, error)` - Check if collection
   exists
-- `CountDocuments(collection string) (int64, error)` - Count documents in
+- `CountDocuments(collection string) (int, error)` - Count documents in
   collection
 
 ### Chat Models
 
-- `GetChatModels() (map[string][]string, error)` - Get all available chat models
+- `GetChatModels() (*ChatModels, error)` - Get all available chat models
   by provider
 - `GetChatModel(provider string) ([]string, error)` - Get models for a specific
   provider

--- a/chat.go
+++ b/chat.go
@@ -146,7 +146,44 @@ type MergeSessionsRequest struct {
 	MergeStrategy MergeStrategy `json:"merge_strategy"`
 }
 
+// ChatModels contains available models for each provider
+type ChatModels struct {
+	OpenAI     []string `json:"openai"`
+	Anthropic  []string `json:"anthropic"`
+	Perplexity []string `json:"perplexity"`
+}
+
 // ========== Chat Methods ==========
+
+// GetChatModels retrieves all available chat models from all providers
+func (c *Client) GetChatModels() (*ChatModels, error) {
+	respBody, err := c.makeRequest("GET", "/api/chat_models", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ChatModels
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetChatModel retrieves available models for a specific provider
+func (c *Client) GetChatModel(providerName string) ([]string, error) {
+	respBody, err := c.makeRequest("GET", fmt.Sprintf("/api/chat_models/%s", providerName), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
 
 // CreateChatSession creates a new chat session
 func (c *Client) CreateChatSession(request CreateChatSessionRequest) (*ChatResponse, error) {
@@ -315,6 +352,21 @@ func (c *Client) UpdateChatMessage(sessionID, messageID, content string) error {
 	request := map[string]string{"content": content}
 	_, err := c.makeRequest("PUT", fmt.Sprintf("/api/chat/%s/messages/%s", sessionID, messageID), request)
 	return err
+}
+
+// GetChatMessage gets a specific message by ID
+func (c *Client) GetChatMessage(sessionID, messageID string) (Record, error) {
+	respBody, err := c.makeRequest("GET", fmt.Sprintf("/api/chat/%s/messages/%s", sessionID, messageID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Record
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // DeleteChatMessage deletes a specific message

--- a/client.go
+++ b/client.go
@@ -1100,6 +1100,33 @@ func (c *Client) DeleteCollection(collection string) error {
 	return err
 }
 
+// CollectionExists checks if a collection exists
+func (c *Client) CollectionExists(collection string) (bool, error) {
+	collections, err := c.ListCollections()
+	if err != nil {
+		return false, err
+	}
+
+	for _, col := range collections {
+		if col == collection {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// CountDocuments counts the number of documents in a collection
+func (c *Client) CountDocuments(collection string) (int, error) {
+	query := NewQueryBuilder().Limit(100000).Build()
+	records, err := c.Find(collection, query)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(records), nil
+}
+
 // RestoreRecord restores a deleted record from trash
 // Records remain in trash for 30 days before permanent deletion
 func (c *Client) RestoreRecord(collection, id string) error {


### PR DESCRIPTION
…s to all clients

Feature parity update across Rust, Python, TypeScript, and Kotlin clients:

Chat Models API:
- get_chat_models() - List all available models by provider
- get_chat_model(provider) - Get models for specific provider
- Examples: client_chat_models.{rs,py,ts,kt}

User Functions API:
- save/get/list/update/delete_user_function()
- Examples: client_user_functions.{rs,py,ts,kt}

Collection Utilities:
- collection_exists() / count_documents()
- Examples: client_collection_utils.{py,ts}

Documentation:
- Updated all client READMEs with new API methods
- Added Makefile test targets for new examples