### PR TITLE
Refactor WebSocket client for auto-reconnect and token management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,77 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-06-04
+
+### Removed
+
+- **Removed the query-builder `regex()` filter** from all clients — the server
+  has no regex filter operator, so it 400'd (or, in Rust, silently fell back to
+  substring `Contains`). Removed until server-side regex filtering is available
+  (tracked internally). Breaking: callers using `regex()` should switch to
+  `contains` / `startsWith` / `endsWith`.
+
+### Changed
+
+- **BREAKING: `QueryBuilder.Page` is now 1-indexed** (#38). `Page(1, n)` is the
+  first page (skip 0), matching `Client.Paginate`; previously `Page` was
+  0-indexed (`page * pageSize`), so the two pagination APIs disagreed. Page
+  numbers below 1 clamp to the first page. Callers using the old 0-indexed
+  `Page` must add 1 to their page numbers.
+- **BREAKING: `ChatMessageStream` now takes a `context.Context`** (#34). The
+  signature is now `ChatMessageStream(ctx, sessionID, request)`, matching the
+  ctx-first convention already used by `SubscribeSSE`. The streaming goroutine
+  select-sends on `ctx.Done()`, so cancelling the context releases the goroutine
+  and the underlying connection even when the consumer stops draining the
+  channel — previously it could block forever on a full buffer and leak.
+  Regression test `TestChatMessageStreamCancellation`. Callers must pass a
+  context (e.g. `context.Background()`).
+
+### Fixed
+
+- **WebSocket `connect()` no longer leaks a socket on a close/dial race** (#41).
+  `Dial` takes no context, so a `Close()` that ran while a dial was in flight
+  could tear down the previous connection and then have the completed dial
+  overwrite `ws.conn` with a freshly-opened socket that was never closed.
+  `connect()` now re-checks `closing` (atomically against `Close()`, which sets
+  it under `ws.mu` before nil'ing `ws.conn`) after dialing: if the client is
+  closing it closes the new connection and returns an error instead of storing
+  it. Regression test added.
+- **WebSocket subscriptions now auto-reconnect** (#37). On an unexpected
+  disconnect the client no longer closes every subscription channel and gives
+  up. It now reconnects with capped exponential backoff + jitter (200ms → ~5s),
+  re-sends the `Subscribe` request for every tracked subscription, and resumes
+  delivery on the SAME caller-held channels. Each (re)connect reads a FRESH
+  token from the parent client, so a since-expired JWT is refreshed
+  transparently instead of permanently locking the connection out. In-flight
+  request and chat-stream callers are failed with an error on the drop (instead
+  of hanging), and an intentional `Close()` cleanly stops the reconnect loop.
+  Previously a transient drop permanently closed all subscriptions and a stale
+  token could never recover. Covered by
+  `TestWebSocketReconnectResumesSubscription`,
+  `TestWebSocketReconnectDialsWithToken`, and
+  `TestWebSocketCloseStopsReconnection`.
+- **Network-error retries use exponential backoff with full jitter** (#36).
+  Replaced the fixed 3s delay with a capped exponential schedule (200ms → 5s)
+  plus full jitter, so concurrent clients don't retry in lockstep. Covered by
+  `TestRetryBackoffBase` / `TestRetryBackoffJitterBounds`. (Making the retry
+  sleep itself context-cancellable requires threading a `context.Context`
+  through the request path and is tracked as follow-up work.)
+- **Data race on `rateLimitInfo`** (#33). `extractRateLimitInfo` wrote the field
+  on every response while `GetRateLimitInfo` / `IsNearRateLimit` read it without
+  synchronization. Added a dedicated `sync.RWMutex` guarding all access; the
+  write now publishes a fully-built value under the lock. Regression test
+  `TestExtractRateLimitInfoNoDataRace` runs clean under `-race`.
+- **`GetValue` no longer corrupts user objects** (#35). It previously unwrapped
+  any object containing a `value` key, so a legitimate object like
+  `{"value": 1, "currency": "USD"}` lost its sibling fields on read. It now only
+  unwraps a genuine typed wrapper (both `type` and `value` present) and passes
+  every other object through untouched. Covered by
+  `TestGetValuePassesThroughUserObjectWithValueKey`.
+- **Corrected the serialization-default docstring** (#38). The
+  `NewClientWithConfig` comment claimed "Default is JSON" although the zero
+  value selects MessagePack.
+
 ## [0.19.0] - 2026-06-02
 
 ### Added
@@ -90,8 +161,7 @@ and this project adheres to
   server's path-routed dispatcher.
 - **Tests** — 4 JWT builder-shape / JSON round-trip cases and 3 EmailSend shape
   cases. Server-side reject paths (wrong secret, expired token, unsupported
-  algorithm) are covered by the Rust integration tests in
-  `ekodb/ekodb_server/tests/function_parameters_tests.rs`. Two new
+  algorithm) are covered by server-side integration tests. Two new
   `TestUserFunction_jsonIncludesHTTPFieldsWhenSet` /
   `_jsonOmitsHTTPFieldsWhenNil` tests guard the `http_method` / `http_path` JSON
   tags + omitempty behavior for the path-routed dispatcher.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,6 @@ results, err := client.Find("users", query)
 - `Contains(field, value)` - String contains
 - `StartsWith(field, value)` - String starts with
 - `EndsWith(field, value)` - String ends with
-- `Regex(field, pattern)` - Regex match
 - `SortAscending(field)` / `SortDescending(field)` - Sorting
 - `Limit(n)` / `Skip(n)` - Pagination
 - `Build()` - Build the query

--- a/chat.go
+++ b/chat.go
@@ -807,7 +807,9 @@ func (c *Client) CompactChat(sessionID string, keepRecent *int) (*CompactChatRes
 //
 // Example:
 //
-//	ch, err := client.ChatMessageStream("chat-id", ChatMessageRequest{Message: "Hello"})
+//	ctx, cancel := context.WithCancel(context.Background())
+//	defer cancel()
+//	ch, err := client.ChatMessageStream(ctx, "chat-id", ChatMessageRequest{Message: "Hello"})
 //	if err != nil { log.Fatal(err) }
 //	for event := range ch {
 //	    switch event.Type {
@@ -819,13 +821,13 @@ func (c *Client) CompactChat(sessionID string, keepRecent *int) (*CompactChatRes
 //	        fmt.Println("Error:", event.Error)
 //	    }
 //	}
-func (c *Client) ChatMessageStream(sessionID string, request ChatMessageRequest) (chan ChatStreamEvent, error) {
+func (c *Client) ChatMessageStream(ctx context.Context, sessionID string, request ChatMessageRequest) (chan ChatStreamEvent, error) {
 	bodyBytes, err := json.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", c.baseURL+fmt.Sprintf("/api/chat/%s/messages/stream", sessionID), bytes.NewReader(bodyBytes))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+fmt.Sprintf("/api/chat/%s/messages/stream", sessionID), bytes.NewReader(bodyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -857,6 +859,18 @@ func (c *Client) ChatMessageStream(sessionID string, request ChatMessageRequest)
 		defer resp.Body.Close()
 		defer close(ch)
 
+		// send delivers an event but never blocks forever: if the consumer stops
+		// draining (or cancels ctx), the select unblocks via ctx.Done() so this
+		// goroutine and the underlying connection are released instead of leaking.
+		send := func(ev ChatStreamEvent) bool {
+			select {
+			case ch <- ev:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -874,7 +888,9 @@ func (c *Client) ChatMessageStream(sessionID string, request ChatMessageRequest)
 
 			// Token chunk
 			if tok, ok := eventData["token"].(string); ok {
-				ch <- ChatStreamEvent{Type: "chunk", Content: tok}
+				if !send(ChatStreamEvent{Type: "chunk", Content: tok}) {
+					return
+				}
 			}
 
 			// Done event (has "content" field)
@@ -899,13 +915,13 @@ func (c *Client) ChatMessageStream(sessionID string, request ChatMessageRequest)
 				if cw, ok := eventData["context_window"].(float64); ok {
 					event.ContextWindow = uint32(cw)
 				}
-				ch <- event
+				send(event)
 				return
 			}
 
 			// Error event
 			if errMsg, ok := eventData["error"].(string); ok {
-				ch <- ChatStreamEvent{Type: "error", Error: errMsg}
+				send(ChatStreamEvent{Type: "error", Error: errMsg})
 				return
 			}
 		}

--- a/chat.go
+++ b/chat.go
@@ -822,6 +822,12 @@ func (c *Client) CompactChat(sessionID string, keepRecent *int) (*CompactChatRes
 //	    }
 //	}
 func (c *Client) ChatMessageStream(ctx context.Context, sessionID string, request ChatMessageRequest) (chan ChatStreamEvent, error) {
+	// Guard against a nil context: NewRequestWithContext and the send helper's
+	// ctx.Done() would both panic on nil. Treat it as Background().
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	bodyBytes, err := json.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)

--- a/chat_test.go
+++ b/chat_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ============================================================================
@@ -193,7 +194,7 @@ func TestChatMessageStream(t *testing.T) {
 	defer server.Close()
 
 	client := createTestClient(t, server)
-	ch, err := client.ChatMessageStream("session_1", ChatMessageRequest{Message: "Hi"})
+	ch, err := client.ChatMessageStream(context.Background(), "session_1", ChatMessageRequest{Message: "Hi"})
 	if err != nil {
 		t.Fatalf("ChatMessageStream failed: %v", err)
 	}
@@ -243,7 +244,7 @@ func TestChatMessageStreamError(t *testing.T) {
 	defer server.Close()
 
 	client := createTestClient(t, server)
-	ch, err := client.ChatMessageStream("session_1", ChatMessageRequest{Message: "Hi"})
+	ch, err := client.ChatMessageStream(context.Background(), "session_1", ChatMessageRequest{Message: "Hi"})
 	if err != nil {
 		t.Fatalf("ChatMessageStream failed: %v", err)
 	}
@@ -272,10 +273,78 @@ func TestChatMessageStreamHTTPError(t *testing.T) {
 	defer server.Close()
 
 	client := createTestClient(t, server)
-	_, err := client.ChatMessageStream("session_1", ChatMessageRequest{Message: "Hi"})
+	_, err := client.ChatMessageStream(context.Background(), "session_1", ChatMessageRequest{Message: "Hi"})
 	if err == nil {
 		t.Fatal("Expected error for HTTP 500")
 	}
+}
+
+// TestChatMessageStreamCancellation is the regression for #34: cancelling the
+// context must release the streaming goroutine and connection even when the
+// consumer stops draining the channel (so it can never leak).
+func TestChatMessageStreamCancellation(t *testing.T) {
+	released := make(chan struct{})
+	server := createTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/chat/session_1/messages/stream": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Fatal("ResponseWriter does not support Flusher")
+			}
+			// Stream forever until the client disconnects (ctx cancel).
+			defer close(released)
+			for {
+				select {
+				case <-r.Context().Done():
+					return
+				default:
+				}
+				if _, err := fmt.Fprintf(w, "data:{\"token\":\"x\"}\n\n"); err != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		},
+	})
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := client.ChatMessageStream(ctx, "session_1", ChatMessageRequest{Message: "Hi"})
+	if err != nil {
+		t.Fatalf("ChatMessageStream failed: %v", err)
+	}
+
+	// Read one event, then stop draining and cancel.
+	<-ch
+	cancel()
+
+	// The channel must close (goroutine exits) promptly.
+	select {
+	case _, open := <-drainUntilClosed(ch):
+		_ = open
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream goroutine did not exit after context cancellation (leak)")
+	}
+
+	// And the server handler must observe the disconnect.
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not observe client disconnect after cancellation")
+	}
+}
+
+// drainUntilClosed reads from ch until it is closed, then signals on the returned
+// channel. Used to detect goroutine exit without blocking the test forever.
+func drainUntilClosed(ch chan ChatStreamEvent) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		for range ch {
+		}
+		close(done)
+	}()
+	return done
 }
 
 // ============================================================================

--- a/chat_test.go
+++ b/chat_test.go
@@ -347,6 +347,43 @@ func drainUntilClosed(ch chan ChatStreamEvent) <-chan struct{} {
 	return done
 }
 
+// TestChatMessageStreamNilContext verifies a nil context is treated as
+// Background() instead of panicking in NewRequestWithContext / ctx.Done().
+func TestChatMessageStreamNilContext(t *testing.T) {
+	server := createTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/chat/session_1/messages/stream": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Fatal("ResponseWriter does not support Flusher")
+			}
+			fmt.Fprintf(w, "data:{\"token\":\"Hi\"}\n\n")
+			flusher.Flush()
+			fmt.Fprintf(w, "data:{\"content\":\"Hi\",\"message_id\":\"m1\"}\n\n")
+			flusher.Flush()
+		},
+	})
+	defer server.Close()
+
+	client := createTestClient(t, server)
+
+	var nilCtx context.Context // nil — must not panic
+	ch, err := client.ChatMessageStream(nilCtx, "session_1", ChatMessageRequest{Message: "Hi"})
+	if err != nil {
+		t.Fatalf("ChatMessageStream with nil context returned error: %v", err)
+	}
+
+	got := false
+	for ev := range ch {
+		if ev.Type == "chunk" || ev.Type == "end" {
+			got = true
+		}
+	}
+	if !got {
+		t.Fatal("expected events from stream invoked with a nil context")
+	}
+}
+
 // ============================================================================
 // Raw Completion Stream With Progress Tests
 // ============================================================================

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -103,6 +104,7 @@ type Client struct {
 	maxRetries    int
 	format        SerializationFormat
 	rateLimitInfo *RateLimitInfo
+	rateLimitMu   sync.RWMutex // Guards rateLimitInfo (written per response, read by callers)
 	schemaCache   *SchemaCache // Optional schema cache for primary_key_alias resolution
 }
 
@@ -144,7 +146,7 @@ func NewClientWithConfig(config ClientConfig) (*Client, error) {
 		apiKey:      config.APIKey,
 		shouldRetry: config.ShouldRetry,
 		maxRetries:  config.MaxRetries,
-		format:      config.Format, // Default is JSON (0 value)
+		format:      config.Format, // Default is MessagePack (0 value = MessagePack)
 		httpClient: &http.Client{
 			Timeout: config.Timeout,
 		},
@@ -169,11 +171,15 @@ func NewClientWithConfig(config ClientConfig) (*Client, error) {
 
 // GetRateLimitInfo returns the current rate limit information
 func (c *Client) GetRateLimitInfo() *RateLimitInfo {
+	c.rateLimitMu.RLock()
+	defer c.rateLimitMu.RUnlock()
 	return c.rateLimitInfo
 }
 
 // IsNearRateLimit checks if approaching rate limit
 func (c *Client) IsNearRateLimit() bool {
+	c.rateLimitMu.RLock()
+	defer c.rateLimitMu.RUnlock()
 	if c.rateLimitInfo == nil {
 		return false
 	}
@@ -307,6 +313,33 @@ func (c *Client) ClearTokenCache() {
 	c.tokenExpiry = 0
 }
 
+// retryBackoffBase returns the deterministic, capped exponential backoff for a
+// (0-indexed) retry attempt: 200ms, 400ms, 800ms, ... clamped to 5s. It never
+// overflows regardless of attempt count.
+func retryBackoffBase(attempt int) time.Duration {
+	const base = 200 * time.Millisecond
+	const maxDelay = 5 * time.Second
+	if attempt < 0 {
+		attempt = 0
+	}
+	d := base
+	for i := 0; i < attempt; i++ {
+		d *= 2
+		if d >= maxDelay {
+			return maxDelay
+		}
+	}
+	return d
+}
+
+// retryBackoff applies full jitter to the capped exponential base, returning a
+// delay in [base/2, base] so concurrent clients don't retry in lockstep.
+func retryBackoff(attempt int) time.Duration {
+	d := retryBackoffBase(attempt)
+	half := d / 2
+	return half + time.Duration(rand.Int64N(int64(half)+1))
+}
+
 // extractRateLimitInfo extracts rate limit information from response headers
 func (c *Client) extractRateLimitInfo(resp *http.Response) {
 	limitStr := resp.Header.Get("X-RateLimit-Limit")
@@ -318,16 +351,20 @@ func (c *Client) extractRateLimitInfo(resp *http.Response) {
 		remaining, _ := strconv.Atoi(remainingStr)
 		reset, _ := strconv.ParseInt(resetStr, 10, 64)
 
-		c.rateLimitInfo = &RateLimitInfo{
+		info := &RateLimitInfo{
 			Limit:     limit,
 			Remaining: remaining,
 			Reset:     reset,
 		}
 
+		c.rateLimitMu.Lock()
+		c.rateLimitInfo = info
+		c.rateLimitMu.Unlock()
+
 		// Log warning if approaching rate limit
-		if c.rateLimitInfo.IsNearLimit() {
+		if info.IsNearLimit() {
 			log.Printf("Warning: Approaching rate limit: %d/%d remaining (%.1f%%)",
-				c.rateLimitInfo.Remaining, c.rateLimitInfo.Limit, c.rateLimitInfo.RemainingPercentage())
+				info.Remaining, info.Limit, info.RemainingPercentage())
 		}
 	}
 }
@@ -383,9 +420,11 @@ func (c *Client) makeRequestWithRetry(method, path string, data interface{}, att
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		// Handle network errors with retry
+		// Handle network errors with retry, using exponential backoff with full
+		// jitter (instead of a fixed delay) so concurrent clients don't retry in
+		// lockstep and a flapping server isn't hammered.
 		if c.shouldRetry && attempt < c.maxRetries {
-			retryDelay := 3 * time.Second
+			retryDelay := retryBackoff(attempt)
 			log.Printf("Network error, retrying after %v...", retryDelay)
 			time.Sleep(retryDelay)
 			return c.makeRequestWithRetry(method, path, data, attempt+1)

--- a/query_builder.go
+++ b/query_builder.go
@@ -177,18 +177,8 @@ func (qb *QueryBuilder) EndsWith(field string, suffix string) *QueryBuilder {
 	return qb
 }
 
-// Regex adds a regex pattern match filter
-func (qb *QueryBuilder) Regex(field string, pattern string) *QueryBuilder {
-	qb.filters = append(qb.filters, map[string]interface{}{
-		"type": "Condition",
-		"content": map[string]interface{}{
-			"field":    field,
-			"operator": "Regex",
-			"value":    pattern,
-		},
-	})
-	return qb
-}
+// Note: regex filtering is pending server-side support. The server has no
+// Regex filter operator; use Contains/StartsWith/EndsWith instead.
 
 // And combines filters with AND logic
 func (qb *QueryBuilder) And(conditions []map[string]interface{}) *QueryBuilder {
@@ -256,9 +246,15 @@ func (qb *QueryBuilder) Skip(skip int) *QueryBuilder {
 	return qb
 }
 
-// Page sets page number and page size (convenience method)
+// Page sets the page number and page size (convenience method).
+//
+// Page numbers are 1-indexed: page 1 is the first page. This matches
+// Client.Paginate. Values below 1 are treated as page 1.
 func (qb *QueryBuilder) Page(page, pageSize int) *QueryBuilder {
-	skip := page * pageSize
+	if page < 1 {
+		page = 1
+	}
+	skip := (page - 1) * pageSize
 	qb.skip = &skip
 	qb.limit = &pageSize
 	return qb

--- a/query_builder_test.go
+++ b/query_builder_test.go
@@ -192,17 +192,6 @@ func TestQueryBuilderEndsWith(t *testing.T) {
 	}
 }
 
-func TestQueryBuilderRegex(t *testing.T) {
-	qb := NewQueryBuilder().Regex("phone", "^\\+1")
-	query := qb.Build()
-
-	filter := query["filter"].(map[string]interface{})
-	content := filter["content"].(map[string]interface{})
-	if content["operator"] != "Regex" {
-		t.Errorf("Expected operator Regex, got %v", content["operator"])
-	}
-}
-
 // ============================================================================
 // Logical Operators Tests
 // ============================================================================
@@ -390,25 +379,26 @@ func TestQueryBuilderSkip(t *testing.T) {
 }
 
 func TestQueryBuilderPage(t *testing.T) {
-	// Page 2 with 20 items per page = skip 40
+	// 1-indexed: page 2 with 20 items per page = skip 20
 	qb := NewQueryBuilder().Page(2, 20)
 	query := qb.Build()
 
 	if query["limit"] != 20 {
 		t.Errorf("Expected limit 20, got %v", query["limit"])
 	}
-	if query["skip"] != 40 {
-		t.Errorf("Expected skip 40, got %v", query["skip"])
+	if query["skip"] != 20 {
+		t.Errorf("Expected skip 20, got %v", query["skip"])
 	}
 }
 
-func TestQueryBuilderPageZero(t *testing.T) {
-	// Page 0 with 10 items = skip 0
-	qb := NewQueryBuilder().Page(0, 10)
-	query := qb.Build()
-
-	if query["skip"] != 0 {
-		t.Errorf("Expected skip 0, got %v", query["skip"])
+func TestQueryBuilderPageFirst(t *testing.T) {
+	// 1-indexed: page 1 (the first page) = skip 0
+	if got := NewQueryBuilder().Page(1, 10).Build()["skip"]; got != 0 {
+		t.Errorf("Expected skip 0 for page 1, got %v", got)
+	}
+	// Out-of-range page numbers clamp to the first page.
+	if got := NewQueryBuilder().Page(0, 10).Build()["skip"]; got != 0 {
+		t.Errorf("Expected skip 0 for clamped page 0, got %v", got)
 	}
 }
 

--- a/rate_limit_test.go
+++ b/rate_limit_test.go
@@ -1,0 +1,43 @@
+package ekodb
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// TestExtractRateLimitInfoNoDataRace exercises concurrent writes (extractRateLimitInfo)
+// and reads (GetRateLimitInfo / IsNearRateLimit) of rateLimitInfo. Run under `go test -race`
+// it fails if the field is accessed without synchronization. Regression for #33.
+func TestExtractRateLimitInfoNoDataRace(t *testing.T) {
+	c := &Client{}
+
+	var wg sync.WaitGroup
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		wg.Add(2)
+		go func(n int) {
+			defer wg.Done()
+			resp := &http.Response{Header: http.Header{}}
+			resp.Header.Set("X-RateLimit-Limit", "1000")
+			resp.Header.Set("X-RateLimit-Remaining", strconv.Itoa(1000-n))
+			resp.Header.Set("X-RateLimit-Reset", "1700000000")
+			c.extractRateLimitInfo(resp)
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = c.GetRateLimitInfo()
+			_ = c.IsNearRateLimit()
+		}()
+	}
+	wg.Wait()
+
+	info := c.GetRateLimitInfo()
+	if info == nil {
+		t.Fatal("expected rate limit info to be set")
+	}
+	if info.Limit != 1000 {
+		t.Fatalf("expected Limit=1000, got %d", info.Limit)
+	}
+}

--- a/retry_backoff_test.go
+++ b/retry_backoff_test.go
@@ -1,0 +1,41 @@
+package ekodb
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRetryBackoffBase verifies the deterministic capped exponential schedule
+// and that it never overflows (regression for #36).
+func TestRetryBackoffBase(t *testing.T) {
+	cases := map[int]time.Duration{
+		0: 200 * time.Millisecond,
+		1: 400 * time.Millisecond,
+		2: 800 * time.Millisecond,
+		3: 1600 * time.Millisecond,
+		4: 3200 * time.Millisecond,
+		5: 5 * time.Second, // capped
+	}
+	for attempt, want := range cases {
+		if got := retryBackoffBase(attempt); got != want {
+			t.Errorf("retryBackoffBase(%d) = %v, want %v", attempt, got, want)
+		}
+	}
+	// Large attempt counts must stay capped and never overflow/panic.
+	if got := retryBackoffBase(1_000_000); got != 5*time.Second {
+		t.Errorf("retryBackoffBase(1e6) = %v, want 5s (capped)", got)
+	}
+}
+
+// TestRetryBackoffJitterBounds verifies full-jitter stays within [base/2, base].
+func TestRetryBackoffJitterBounds(t *testing.T) {
+	for attempt := 0; attempt < 8; attempt++ {
+		base := retryBackoffBase(attempt)
+		for i := 0; i < 200; i++ {
+			d := retryBackoff(attempt)
+			if d < base/2 || d > base {
+				t.Fatalf("retryBackoff(%d) = %v, out of bounds [%v, %v]", attempt, d, base/2, base)
+			}
+		}
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -195,10 +195,15 @@ func GetValue(field interface{}) interface{} {
 		return nil
 	}
 
-	// Try to cast to map[string]interface{} (JSON object)
+	// Try to cast to map[string]interface{} (JSON object). Only unwrap a genuine
+	// typed wrapper — one that carries BOTH a "type" discriminator and a "value".
+	// A user object that merely has a "value" key (e.g. {"value":1,"currency":"USD"})
+	// must pass through untouched.
 	if fieldMap, ok := field.(map[string]interface{}); ok {
-		if value, exists := fieldMap["value"]; exists {
-			return value
+		if _, hasType := fieldMap["type"]; hasType {
+			if value, exists := fieldMap["value"]; exists {
+				return value
+			}
 		}
 	}
 

--- a/utils_value_test.go
+++ b/utils_value_test.go
@@ -1,0 +1,44 @@
+package ekodb
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestGetValueUnwrapsTypedWrapper confirms a genuine {type,value} wrapper is unwrapped.
+func TestGetValueUnwrapsTypedWrapper(t *testing.T) {
+	in := map[string]interface{}{"type": "String", "value": "hi"}
+	if got := GetValue(in); got != "hi" {
+		t.Fatalf("expected unwrapped \"hi\", got %v", got)
+	}
+}
+
+// TestGetValuePassesThroughUserObjectWithValueKey is the regression for #35: a user object
+// that merely has a "value" key (but no "type" discriminator) must NOT be unwrapped.
+func TestGetValuePassesThroughUserObjectWithValueKey(t *testing.T) {
+	in := map[string]interface{}{"value": float64(1), "currency": "USD"}
+	got := GetValue(in)
+	m, ok := got.(map[string]interface{})
+	if !ok || !reflect.DeepEqual(m, in) {
+		t.Fatalf("expected the user object to pass through unchanged, got %v", got)
+	}
+}
+
+// TestGetValuePassThroughNonMapAndNil covers scalars and nil.
+func TestGetValuePassThroughNonMapAndNil(t *testing.T) {
+	if got := GetValue("raw"); got != "raw" {
+		t.Fatalf("expected raw scalar passthrough, got %v", got)
+	}
+	if got := GetValue(nil); got != nil {
+		t.Fatalf("expected nil passthrough, got %v", got)
+	}
+}
+
+// TestGetStringValueOnUserObjectIsEmpty confirms the typed extractor does not mis-read
+// a user object with a "value" key as that inner value.
+func TestGetStringValueOnUserObjectIsEmpty(t *testing.T) {
+	in := map[string]interface{}{"value": "inner", "currency": "USD"}
+	if got := GetStringValue(in); got != "" {
+		t.Fatalf("expected empty string (object is not a typed wrapper), got %q", got)
+	}
+}

--- a/websocket.go
+++ b/websocket.go
@@ -376,17 +376,22 @@ func (ws *WebSocketClient) readLoop(conn *websocket.Conn) {
 				delete(ws.chatStreams, id)
 			}
 			closing := ws.closing
-			// Collect subscription channels only if we are shutting down for
-			// good; on an unexpected drop we leave them untouched for replay.
+			// Reconnect exists solely to keep ACTIVE subscriptions alive across a
+			// transient drop. With nothing to replay (a one-shot request or a
+			// finished chat stream), an unexpected drop is terminal — tear down
+			// instead of spinning a background reconnect loop.
+			reconnect := !closing && len(ws.subscriptions) > 0
+			// Collect subscription channels to close unless we're reconnecting
+			// (in which case they stay open and get re-subscribed).
 			var subChans map[string]chan MutationNotification
-			if closing {
+			if reconnect {
+				ws.reconnecting = true
+			} else {
 				subChans = make(map[string]chan MutationNotification)
 				for id, ch := range ws.subscriptions {
 					subChans[id] = ch
 					delete(ws.subscriptions, id)
 				}
-			} else {
-				ws.reconnecting = true
 			}
 			ws.mu.Unlock()
 
@@ -413,15 +418,21 @@ func (ws *WebSocketClient) readLoop(conn *websocket.Conn) {
 			ws.conn = nil
 			ws.writeMu.Unlock()
 
-			if closing {
-				ws.cancel()
+			if !reconnect {
+				// Terminal: either an intentional Close() or an unexpected drop
+				// with no subscriptions to replay. End the dispatcher. Only an
+				// intentional Close() cancels the context (so a still-usable
+				// client isn't invalidated by a transient drop).
+				if closing {
+					ws.cancel()
+				}
 				close(done)
 				return
 			}
 
-			// Unexpected drop: spawn the reconnect loop and end this dispatcher.
-			// reconnect() re-arms a fresh readLoop (and a fresh dispatcherDone)
-			// on success. Signal this dispatcher's waiter, then hand off.
+			// Unexpected drop WITH active subscriptions: spawn the reconnect loop
+			// and end this dispatcher. reconnect() re-arms a fresh readLoop (and a
+			// fresh dispatcherDone) on success. Signal this waiter, then hand off.
 			close(done)
 			go ws.reconnect()
 			return

--- a/websocket.go
+++ b/websocket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"strings"
 	"sync"
@@ -63,19 +64,31 @@ type SubscribeOptions struct {
 // WebSocketClient represents a WebSocket connection to ekoDB with full dispatcher.
 type WebSocketClient struct {
 	wsURL string
-	token string
 	conn  *websocket.Conn
 
+	// tokenProvider returns a fresh auth token on every (re)connect. It is
+	// read on each dial so a since-expired JWT can be refreshed transparently.
+	tokenProvider func() string
+
 	writeMu         sync.Mutex // serializes all writes to ws.conn
-	mu              sync.Mutex // protects maps
+	mu              sync.Mutex // protects maps + closing/reconnecting flags
 	pendingRequests map[string]chan wsResponse
 	subscriptions   map[string]chan MutationNotification
-	chatStreams     map[string]chan ChatStreamEvent
-	dispatcherDone  chan struct{}
-	ctx             context.Context
-	cancel          context.CancelFunc
-	messageCounter  atomic.Int64
-	schemaCache     *SchemaCache // optional, for auto-invalidation on SchemaChanged
+	// subParams records the parameters used for each active subscription so
+	// the subscribe request can be replayed after an automatic reconnect.
+	subParams      map[string]SubscribeOptions
+	chatStreams    map[string]chan ChatStreamEvent
+	dispatcherDone chan struct{}
+	ctx            context.Context
+	cancel         context.CancelFunc
+	messageCounter atomic.Int64
+	schemaCache    *SchemaCache // optional, for auto-invalidation on SchemaChanged
+
+	// closing is set by Close() so the reconnect loop exits cleanly and an
+	// intentional shutdown is never mistaken for a transient drop.
+	closing bool
+	// reconnecting guards against spawning more than one reconnect loop.
+	reconnecting bool
 }
 
 type wsResponse struct {
@@ -88,9 +101,10 @@ func (c *Client) WebSocket(wsURL string) (*WebSocketClient, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ws := &WebSocketClient{
 		wsURL:           wsURL,
-		token:           c.getToken(),
+		tokenProvider:   c.getToken,
 		pendingRequests: make(map[string]chan wsResponse),
 		subscriptions:   make(map[string]chan MutationNotification),
+		subParams:       make(map[string]SubscribeOptions),
 		chatStreams:     make(map[string]chan ChatStreamEvent),
 		ctx:             ctx,
 		cancel:          cancel,
@@ -160,7 +174,9 @@ func (c *Client) ExtractRecordID(collection string, record map[string]interface{
 	return ""
 }
 
-// connect establishes a WebSocket connection.
+// connect establishes a WebSocket connection. A FRESH token is fetched from
+// tokenProvider on every call so a since-expired JWT is refreshed (via the
+// parent client's proactive-refresh mechanism) before each (re)connect.
 func (ws *WebSocketClient) connect() error {
 	u, err := url.Parse(ws.wsURL)
 	if err != nil {
@@ -173,20 +189,136 @@ func (ws *WebSocketClient) connect() error {
 		u.Path = strings.TrimRight(u.Path, "/") + "/api/ws"
 	}
 
+	var token string
+	if ws.tokenProvider != nil {
+		token = ws.tokenProvider()
+	}
+
 	q := u.Query()
-	q.Set("token", ws.token)
+	q.Set("token", token)
 	u.RawQuery = q.Encode()
 
 	header := make(map[string][]string)
-	header["Authorization"] = []string{"Bearer " + ws.token}
+	header["Authorization"] = []string{"Bearer " + token}
 
 	conn, _, err := websocket.DefaultDialer.Dial(u.String(), header)
 	if err != nil {
 		return fmt.Errorf("websocket connection failed: %w", err)
 	}
 
+	ws.writeMu.Lock()
 	ws.conn = conn
+	ws.writeMu.Unlock()
 	return nil
+}
+
+// Reconnect backoff bounds for the automatic reconnect loop.
+const (
+	reconnectBaseDelay = 200 * time.Millisecond
+	reconnectMaxDelay  = 5 * time.Second
+)
+
+// reconnect runs the automatic reconnect loop after an unexpected disconnect.
+// It dials again with a FRESH token using capped exponential backoff + jitter,
+// re-sends the subscribe request for every tracked subscription, then resumes
+// the dispatcher. It exits cleanly if Close() is called while it is running.
+func (ws *WebSocketClient) reconnect() {
+	defer func() {
+		ws.mu.Lock()
+		ws.reconnecting = false
+		ws.mu.Unlock()
+	}()
+
+	delay := reconnectBaseDelay
+	for {
+		// Bail out if the caller intentionally closed (or context cancelled).
+		ws.mu.Lock()
+		closing := ws.closing
+		ws.mu.Unlock()
+		if closing {
+			return
+		}
+		select {
+		case <-ws.ctx.Done():
+			return
+		default:
+		}
+
+		// Sleep the backoff window with jitter, but wake immediately on close.
+		jitter := time.Duration(rand.Int63n(int64(delay)/2 + 1))
+		wait := delay + jitter
+		select {
+		case <-ws.ctx.Done():
+			return
+		case <-time.After(wait):
+		}
+
+		ws.mu.Lock()
+		closing = ws.closing
+		ws.mu.Unlock()
+		if closing {
+			return
+		}
+
+		if err := ws.connect(); err != nil {
+			// Dial failed — grow the backoff (capped) and retry.
+			delay *= 2
+			if delay > reconnectMaxDelay {
+				delay = reconnectMaxDelay
+			}
+			continue
+		}
+
+		// Connected. Re-send every tracked subscription so the server resumes
+		// pushing notifications onto the still-open caller channels.
+		ws.resubscribeAll()
+
+		// Install a fresh dispatcherDone for the new readLoop and resume.
+		ws.mu.Lock()
+		if ws.closing {
+			ws.mu.Unlock()
+			return
+		}
+		ws.dispatcherDone = make(chan struct{})
+		conn := ws.conn
+		ws.mu.Unlock()
+
+		go ws.readLoop(conn)
+		return
+	}
+}
+
+// resubscribeAll replays the subscribe request for every tracked subscription
+// after a reconnect. It reads the tracked params under the lock, then sends
+// each request with the lock released (writeJSON does its own locking).
+func (ws *WebSocketClient) resubscribeAll() {
+	ws.mu.Lock()
+	params := make(map[string]SubscribeOptions, len(ws.subParams))
+	for collection, opts := range ws.subParams {
+		params[collection] = opts
+	}
+	ws.mu.Unlock()
+
+	for collection, opts := range params {
+		payload := map[string]interface{}{
+			"collection": collection,
+		}
+		if opts.FilterField != "" {
+			payload["filter_field"] = opts.FilterField
+		}
+		if opts.FilterValue != "" {
+			payload["filter_value"] = opts.FilterValue
+		}
+		request := map[string]interface{}{
+			"type":      "Subscribe",
+			"messageId": ws.genMessageID(),
+			"payload":   payload,
+		}
+		// Fire-and-forget: the subscribe ack is not awaited here. A write
+		// failure means the connection dropped again; the next readLoop error
+		// will retrigger the reconnect loop.
+		_ = ws.writeJSON(request)
+	}
 }
 
 func (ws *WebSocketClient) genMessageID() string {
@@ -207,12 +339,21 @@ func (ws *WebSocketClient) writeJSON(v interface{}) error {
 // readLoop is the dispatcher goroutine that routes incoming messages.
 // conn is passed as a parameter to avoid a data race with Close() which nils ws.conn.
 func (ws *WebSocketClient) readLoop(conn *websocket.Conn) {
-	defer close(ws.dispatcherDone)
+	// done is captured at loop start; reconnect() installs a fresh
+	// dispatcherDone before spawning each new readLoop, so closing the
+	// captured channel always signals the right Close() waiter.
+	ws.mu.Lock()
+	done := ws.dispatcherDone
+	ws.mu.Unlock()
 
 	for {
 		_, data, err := conn.ReadMessage()
 		if err != nil {
-			// Collect channels to notify, then release the lock before sending
+			// Connection dropped. Fail in-flight request/chat callers so they
+			// don't hang, but KEEP subscription channels alive — a transient
+			// drop must not permanently kill subscriptions. If this was an
+			// intentional Close(), tear down for good; otherwise hand off to
+			// the reconnect loop.
 			ws.mu.Lock()
 			pendingChans := make(map[string]chan wsResponse)
 			for id, ch := range ws.pendingRequests {
@@ -224,10 +365,18 @@ func (ws *WebSocketClient) readLoop(conn *websocket.Conn) {
 				chatChans[id] = ch
 				delete(ws.chatStreams, id)
 			}
-			subChans := make(map[string]chan MutationNotification)
-			for id, ch := range ws.subscriptions {
-				subChans[id] = ch
-				delete(ws.subscriptions, id)
+			closing := ws.closing
+			// Collect subscription channels only if we are shutting down for
+			// good; on an unexpected drop we leave them untouched for replay.
+			var subChans map[string]chan MutationNotification
+			if closing {
+				subChans = make(map[string]chan MutationNotification)
+				for id, ch := range ws.subscriptions {
+					subChans[id] = ch
+					delete(ws.subscriptions, id)
+				}
+			} else {
+				ws.reconnecting = true
 			}
 			ws.mu.Unlock()
 
@@ -253,7 +402,18 @@ func (ws *WebSocketClient) readLoop(conn *websocket.Conn) {
 			ws.writeMu.Lock()
 			ws.conn = nil
 			ws.writeMu.Unlock()
-			ws.cancel()
+
+			if closing {
+				ws.cancel()
+				close(done)
+				return
+			}
+
+			// Unexpected drop: spawn the reconnect loop and end this dispatcher.
+			// reconnect() re-arms a fresh readLoop (and a fresh dispatcherDone)
+			// on success. Signal this dispatcher's waiter, then hand off.
+			close(done)
+			go ws.reconnect()
 			return
 		}
 
@@ -645,6 +805,12 @@ func (ws *WebSocketClient) Subscribe(collection string, opts ...SubscribeOptions
 		"payload":   payload,
 	}
 
+	// Capture the params for replay after an automatic reconnect.
+	var subOpts SubscribeOptions
+	if len(opts) > 0 {
+		subOpts = opts[0]
+	}
+
 	// Register subscription channel before sending
 	ch := make(chan MutationNotification, 64)
 	ws.mu.Lock()
@@ -653,17 +819,33 @@ func (ws *WebSocketClient) Subscribe(collection string, opts ...SubscribeOptions
 		return nil, fmt.Errorf("already subscribed to collection %q", collection)
 	}
 	ws.subscriptions[collection] = ch
+	ws.subParams[collection] = subOpts
 	ws.mu.Unlock()
 
 	_, err := ws.sendRequest(request, messageID)
 	if err != nil {
 		ws.mu.Lock()
 		delete(ws.subscriptions, collection)
+		delete(ws.subParams, collection)
 		ws.mu.Unlock()
 		return nil, err
 	}
 
 	return ch, nil
+}
+
+// Unsubscribe removes a subscription so it is no longer replayed on reconnect
+// and closes its notification channel. It is safe to call for a collection
+// that is not currently subscribed (no-op).
+func (ws *WebSocketClient) Unsubscribe(collection string) {
+	ws.mu.Lock()
+	ch, ok := ws.subscriptions[collection]
+	delete(ws.subscriptions, collection)
+	delete(ws.subParams, collection)
+	ws.mu.Unlock()
+	if ok {
+		close(ch)
+	}
 }
 
 // ChatSend sends a chat message and returns a channel of streaming events.
@@ -1115,8 +1297,29 @@ func (ws *WebSocketClient) DeleteCollection(name string) error {
 	return err
 }
 
-// Close closes the WebSocket connection and cleans up resources.
+// Close closes the WebSocket connection and cleans up resources. It marks the
+// client as closing FIRST so any in-flight reconnect loop exits cleanly and the
+// dispatcher does not treat the resulting read error as a transient drop.
 func (ws *WebSocketClient) Close() error {
+	ws.mu.Lock()
+	if ws.closing {
+		// Already closing/closed — idempotent.
+		ws.mu.Unlock()
+		return nil
+	}
+	ws.closing = true
+	reconnecting := ws.reconnecting
+	done := ws.dispatcherDone
+	// Close subscription channels so callers ranging over them unblock. The
+	// reconnect loop is gated on ws.closing, so it will not replay these.
+	for collection, ch := range ws.subscriptions {
+		delete(ws.subscriptions, collection)
+		delete(ws.subParams, collection)
+		close(ch)
+	}
+	ws.mu.Unlock()
+
+	// Cancel context first so the reconnect loop's sleep/dial wakes and exits.
 	ws.cancel()
 
 	ws.writeMu.Lock()
@@ -1124,12 +1327,16 @@ func (ws *WebSocketClient) Close() error {
 	ws.conn = nil
 	ws.writeMu.Unlock()
 
+	var err error
 	if conn != nil {
-		err := conn.Close()
-		if ws.dispatcherDone != nil {
-			<-ws.dispatcherDone
-		}
-		return err
+		err = conn.Close()
 	}
-	return nil
+
+	// Only wait on the dispatcher if a readLoop is actually running. When a
+	// reconnect loop is mid-backoff there is no live dispatcher to drain (its
+	// previous done was already closed), so waiting would block forever.
+	if conn != nil && !reconnecting && done != nil {
+		<-done
+	}
+	return err
 }

--- a/websocket.go
+++ b/websocket.go
@@ -87,7 +87,10 @@ type WebSocketClient struct {
 	// closing is set by Close() so the reconnect loop exits cleanly and an
 	// intentional shutdown is never mistaken for a transient drop.
 	closing bool
-	// reconnecting guards against spawning more than one reconnect loop.
+	// reconnecting indicates a reconnect loop is currently running (set when a
+	// drop is handed off to reconnect(), cleared once a new dispatcher is up).
+	// Close() reads it to skip waiting on dispatcherDone when no dispatcher
+	// goroutine is active (e.g. the reconnect loop is mid-backoff).
 	reconnecting bool
 }
 

--- a/websocket.go
+++ b/websocket.go
@@ -209,9 +209,21 @@ func (ws *WebSocketClient) connect() error {
 		return fmt.Errorf("websocket connection failed: %w", err)
 	}
 
+	// If Close() ran while the (context-less) Dial was in flight, don't store
+	// the freshly-dialed connection. Close() has already torn down the previous
+	// conn and will never see this one, so storing it would leak an open socket.
+	// Holding ws.mu across the closing check and the store keeps it atomic vs
+	// Close(), which sets ws.closing under ws.mu before nil'ing ws.conn.
+	ws.mu.Lock()
+	if ws.closing {
+		ws.mu.Unlock()
+		_ = conn.Close()
+		return fmt.Errorf("websocket client closed during connect")
+	}
 	ws.writeMu.Lock()
 	ws.conn = conn
 	ws.writeMu.Unlock()
+	ws.mu.Unlock()
 	return nil
 }
 
@@ -861,9 +873,14 @@ func (ws *WebSocketClient) Subscribe(collection string, opts ...SubscribeOptions
 	return ch, nil
 }
 
-// Unsubscribe removes a subscription so it is no longer replayed on reconnect
-// and closes its notification channel. It is safe to call for a collection
-// that is not currently subscribed (no-op).
+// Unsubscribe stops local delivery for a collection: it removes the subscription
+// so it is no longer replayed on reconnect and closes its notification channel.
+// It is safe to call for a collection that is not currently subscribed (no-op).
+//
+// Note: this only affects the local client. It does not currently send an
+// Unsubscribe message to the server, so the server keeps streaming mutations for
+// this connection until it disconnects. Sending a server-side Unsubscribe is
+// tracked as a cross-client enhancement.
 func (ws *WebSocketClient) Unsubscribe(collection string) {
 	ws.mu.Lock()
 	ch, ok := ws.subscriptions[collection]

--- a/websocket.go
+++ b/websocket.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"strings"
 	"sync"
@@ -245,7 +245,7 @@ func (ws *WebSocketClient) reconnect() {
 		}
 
 		// Sleep the backoff window with jitter, but wake immediately on close.
-		jitter := time.Duration(rand.Int63n(int64(delay)/2 + 1))
+		jitter := time.Duration(rand.Int64N(int64(delay)/2 + 1))
 		wait := delay + jitter
 		select {
 		case <-ws.ctx.Done():
@@ -280,8 +280,18 @@ func (ws *WebSocketClient) reconnect() {
 			return
 		}
 		ws.dispatcherDone = make(chan struct{})
-		conn := ws.conn
 		ws.mu.Unlock()
+
+		// ws.conn is written by connect(), cleared by Close(), and read by
+		// writeJSON() all under writeMu — read it under the same lock here. A
+		// concurrent Close() may have nil'd it, in which case there is nothing
+		// to resume.
+		ws.writeMu.Lock()
+		conn := ws.conn
+		ws.writeMu.Unlock()
+		if conn == nil {
+			return
+		}
 
 		go ws.readLoop(conn)
 		return
@@ -539,17 +549,20 @@ func (ws *WebSocketClient) routeMutationNotification(msg map[string]json.RawMess
 		return
 	}
 
+	// Hold ws.mu across the lookup AND the send. The send is non-blocking
+	// (select/default), so holding the lock cannot deadlock. Close() and
+	// Unsubscribe() remove the channel from the map (and Close() closes it)
+	// under this same lock, so a delivery here can never race a close() and
+	// panic with "send on closed channel".
 	ws.mu.Lock()
-	ch, ok := ws.subscriptions[notification.Collection]
-	ws.mu.Unlock()
-
-	if ok {
+	if ch, ok := ws.subscriptions[notification.Collection]; ok {
 		select {
 		case ch <- notification:
 		default:
-			// Drop if channel full
+			// Drop if the consumer is not keeping up.
 		}
 	}
+	ws.mu.Unlock()
 }
 
 func (ws *WebSocketClient) extractChatID(msg map[string]json.RawMessage) string {

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1753,3 +1753,30 @@ func TestWebSocketUnsubscribeRaceWithDelivery(t *testing.T) {
 	<-writerDone
 	// Reaching here without a panic means deliver-vs-close is safe.
 }
+
+// TestWebSocketNoReconnectWithoutSubscriptions guards that an unexpected drop
+// with no active subscriptions is terminal — the client must NOT spin a
+// background reconnect loop (which would add latency to one-shot/chat WS flows).
+func TestWebSocketNoReconnectWithoutSubscriptions(t *testing.T) {
+	rts := setupReconnectTestServer(t)
+	defer rts.server.Close()
+
+	client := &Client{token: "test-token"}
+	ws, err := client.WebSocket(rts.wsURL)
+	if err != nil {
+		t.Fatalf("failed to create WebSocket client: %v", err)
+	}
+	defer ws.Close()
+
+	conn := <-rts.connCh
+	// No Subscribe — drop the connection unexpectedly.
+	conn.Close()
+
+	select {
+	case c := <-rts.connCh:
+		c.Close()
+		t.Fatal("client reconnected despite having no active subscriptions")
+	case <-time.After(2 * time.Second):
+		// Expected: no reconnect.
+	}
+}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1411,3 +1411,268 @@ func TestWebSocketRawCompletionError(t *testing.T) {
 		t.Fatal("timeout")
 	}
 }
+
+// =========================================================================
+// Auto-reconnect tests (#37)
+// =========================================================================
+
+// reconnectTestServer is a mock WS server that accepts multiple upgrades and
+// records each incoming connection plus the Authorization/token seen on its
+// upgrade request. Used to verify auto-reconnect behaviour.
+type reconnectTestServer struct {
+	server  *httptest.Server
+	wsURL   string
+	connCh  chan *websocket.Conn
+	authCh  chan string // Authorization header per upgrade
+	tokenCh chan string // ?token= query param per upgrade
+}
+
+func setupReconnectTestServer(t *testing.T) *reconnectTestServer {
+	t.Helper()
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+	rts := &reconnectTestServer{
+		connCh:  make(chan *websocket.Conn, 8),
+		authCh:  make(chan string, 8),
+		tokenCh: make(chan string, 8),
+	}
+	rts.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Record auth context before the upgrade hijacks the request.
+		select {
+		case rts.authCh <- r.Header.Get("Authorization"):
+		default:
+		}
+		select {
+		case rts.tokenCh <- r.URL.Query().Get("token"):
+		default:
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+		rts.connCh <- conn
+	}))
+	rts.wsURL = "ws" + strings.TrimPrefix(rts.server.URL, "http") + "/api/ws"
+	return rts
+}
+
+// TestWebSocketReconnectResumesSubscription verifies that a subscription
+// survives a mid-stream server disconnect: the client reconnects, re-sends the
+// Subscribe request, and the SAME channel delivers a post-reconnect mutation.
+func TestWebSocketReconnectResumesSubscription(t *testing.T) {
+	rts := setupReconnectTestServer(t)
+	defer rts.server.Close()
+
+	client := &Client{token: "test-token"}
+	ws, err := client.WebSocket(rts.wsURL)
+	if err != nil {
+		t.Fatalf("failed to create WebSocket client: %v", err)
+	}
+	defer ws.Close()
+
+	conn1 := <-rts.connCh
+
+	// Subscribe (in a goroutine — it blocks on the server ack).
+	subCh := make(chan (<-chan MutationNotification), 1)
+	subErr := make(chan error, 1)
+	go func() {
+		ch, err := ws.Subscribe("orders")
+		if err != nil {
+			subErr <- err
+			return
+		}
+		subCh <- ch
+	}()
+
+	msg := readMessage(t, conn1)
+	if msg["type"] != "Subscribe" {
+		t.Fatalf("expected Subscribe, got %v", msg["type"])
+	}
+	mustWriteJSON(t, conn1, map[string]interface{}{
+		"type":    "Success",
+		"payload": map[string]interface{}{"message_id": msg["messageId"]},
+	})
+
+	var notifCh <-chan MutationNotification
+	select {
+	case notifCh = <-subCh:
+	case err := <-subErr:
+		t.Fatalf("subscribe failed: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for subscribe")
+	}
+
+	// Deliver one mutation, then drop the connection.
+	mustWriteJSON(t, conn1, map[string]interface{}{
+		"type": "MutationNotification",
+		"payload": map[string]interface{}{
+			"collection": "orders",
+			"event":      "insert",
+			"record_ids": []string{"order-1"},
+			"timestamp":  "2026-03-13T00:00:00Z",
+		},
+	})
+	select {
+	case n := <-notifCh:
+		if n.Event != "insert" || len(n.RecordIDs) != 1 || n.RecordIDs[0] != "order-1" {
+			t.Fatalf("unexpected pre-drop notification: %+v", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for pre-drop notification")
+	}
+
+	// Server drops the connection unexpectedly.
+	conn1.Close()
+
+	// Client should reconnect and re-send the Subscribe request.
+	var conn2 *websocket.Conn
+	select {
+	case conn2 = <-rts.connCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("client did not reconnect after drop")
+	}
+	defer conn2.Close()
+
+	resubMsg := readMessage(t, conn2)
+	if resubMsg["type"] != "Subscribe" {
+		t.Fatalf("expected re-sent Subscribe after reconnect, got %v", resubMsg["type"])
+	}
+	rpayload := resubMsg["payload"].(map[string]interface{})
+	if rpayload["collection"] != "orders" {
+		t.Fatalf("expected re-subscribe to orders, got %v", rpayload["collection"])
+	}
+	// Ack the resubscribe (server normally would).
+	mustWriteJSON(t, conn2, map[string]interface{}{
+		"type":    "Success",
+		"payload": map[string]interface{}{"message_id": resubMsg["messageId"]},
+	})
+
+	// A post-reconnect mutation must arrive on the SAME channel.
+	mustWriteJSON(t, conn2, map[string]interface{}{
+		"type": "MutationNotification",
+		"payload": map[string]interface{}{
+			"collection": "orders",
+			"event":      "update",
+			"record_ids": []string{"order-2"},
+			"timestamp":  "2026-03-13T00:01:00Z",
+		},
+	})
+	select {
+	case n := <-notifCh:
+		if n.Event != "update" || len(n.RecordIDs) != 1 || n.RecordIDs[0] != "order-2" {
+			t.Fatalf("unexpected post-reconnect notification: %+v", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for post-reconnect notification on same channel")
+	}
+}
+
+// TestWebSocketReconnectDialsWithToken verifies that a reconnect dial carries a
+// token (both the Authorization header and the ?token= query param).
+func TestWebSocketReconnectDialsWithToken(t *testing.T) {
+	rts := setupReconnectTestServer(t)
+	defer rts.server.Close()
+
+	client := &Client{token: "secret-jwt"}
+	ws, err := client.WebSocket(rts.wsURL)
+	if err != nil {
+		t.Fatalf("failed to create WebSocket client: %v", err)
+	}
+	defer ws.Close()
+
+	conn1 := <-rts.connCh
+
+	// Drain the first connection's auth context.
+	<-rts.authCh
+	<-rts.tokenCh
+
+	// Establish a subscription so reconnect has something to resume.
+	subErr := make(chan error, 1)
+	go func() {
+		_, err := ws.Subscribe("orders")
+		subErr <- err
+	}()
+	msg := readMessage(t, conn1)
+	mustWriteJSON(t, conn1, map[string]interface{}{
+		"type":    "Success",
+		"payload": map[string]interface{}{"message_id": msg["messageId"]},
+	})
+	if err := <-subErr; err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	// Drop to force a reconnect.
+	conn1.Close()
+
+	select {
+	case <-rts.connCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("client did not reconnect")
+	}
+
+	// The reconnect dial must have carried the token.
+	select {
+	case auth := <-rts.authCh:
+		if auth != "Bearer secret-jwt" {
+			t.Fatalf("expected reconnect Authorization 'Bearer secret-jwt', got %q", auth)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no Authorization header captured for reconnect dial")
+	}
+	select {
+	case tok := <-rts.tokenCh:
+		if tok != "secret-jwt" {
+			t.Fatalf("expected reconnect token query 'secret-jwt', got %q", tok)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no token query param captured for reconnect dial")
+	}
+}
+
+// TestWebSocketCloseStopsReconnection verifies that Close() halts reconnection:
+// after Close, the server sees no further dial attempts even though a
+// subscription was active when the connection dropped.
+func TestWebSocketCloseStopsReconnection(t *testing.T) {
+	rts := setupReconnectTestServer(t)
+	defer rts.server.Close()
+
+	client := &Client{token: "test-token"}
+	ws, err := client.WebSocket(rts.wsURL)
+	if err != nil {
+		t.Fatalf("failed to create WebSocket client: %v", err)
+	}
+
+	conn1 := <-rts.connCh
+
+	// Establish a subscription.
+	subErr := make(chan error, 1)
+	go func() {
+		_, err := ws.Subscribe("orders")
+		subErr <- err
+	}()
+	msg := readMessage(t, conn1)
+	mustWriteJSON(t, conn1, map[string]interface{}{
+		"type":    "Success",
+		"payload": map[string]interface{}{"message_id": msg["messageId"]},
+	})
+	if err := <-subErr; err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	// Intentional close — must not trigger a reconnect.
+	if err := ws.Close(); err != nil {
+		t.Fatalf("close returned error: %v", err)
+	}
+	conn1.Close()
+
+	// No new connection should arrive after an intentional Close.
+	select {
+	case c := <-rts.connCh:
+		c.Close()
+		t.Fatal("client attempted to reconnect after Close()")
+	case <-time.After(2 * time.Second):
+		// Expected: no reconnect.
+	}
+}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -51,6 +51,40 @@ func readMessage(t *testing.T, conn *websocket.Conn) map[string]interface{} {
 	return msg
 }
 
+// Regression: connect() must not store (and thus leak) a freshly-dialed
+// connection if Close() already flipped `closing` while the context-less Dial
+// was in flight. Close() tears down the previous conn and never sees the new
+// one, so storing it would leave an open socket that is never closed.
+func TestWebSocketConnectDoesNotLeakWhenClosing(t *testing.T) {
+	wsURL, connCh, server := setupTestWSServer(t)
+	defer server.Close()
+
+	ws := &WebSocketClient{
+		wsURL:         wsURL,
+		tokenProvider: func() string { return "test-token" },
+	}
+	// Simulate Close() having already set `closing` before connect() finishes dialing.
+	ws.closing = true
+
+	if err := ws.connect(); err == nil {
+		t.Fatal("connect() must return an error when the client is already closing")
+	}
+
+	ws.writeMu.Lock()
+	conn := ws.conn
+	ws.writeMu.Unlock()
+	if conn != nil {
+		t.Fatal("connect() must not store a connection when closing (would leak an open socket)")
+	}
+
+	// If the dial reached the server, close that side so the test server shuts down cleanly.
+	select {
+	case sc := <-connCh:
+		sc.Close()
+	case <-time.After(time.Second):
+	}
+}
+
 func TestWebSocketFindAll(t *testing.T) {
 	wsURL, connCh, server := setupTestWSServer(t)
 	defer server.Close()

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1676,3 +1676,80 @@ func TestWebSocketCloseStopsReconnection(t *testing.T) {
 		// Expected: no reconnect.
 	}
 }
+
+// TestWebSocketUnsubscribeRaceWithDelivery exercises the deliver-vs-close race:
+// the server streams mutation notifications while the client Unsubscribes (which
+// closes the subscription channel). Before the fix, the dispatcher sent on the
+// channel outside the lock and could panic with "send on closed channel". Run
+// under `-race` (and `-count`) this is a regression guard for #37 (#5/#6).
+func TestWebSocketUnsubscribeRaceWithDelivery(t *testing.T) {
+	rts := setupReconnectTestServer(t)
+	defer rts.server.Close()
+
+	client := &Client{token: "test-token"}
+	ws, err := client.WebSocket(rts.wsURL)
+	if err != nil {
+		t.Fatalf("failed to create WebSocket client: %v", err)
+	}
+	defer ws.Close()
+
+	conn := <-rts.connCh
+
+	subCh := make(chan (<-chan MutationNotification), 1)
+	go func() {
+		ch, err := ws.Subscribe("orders")
+		if err == nil {
+			subCh <- ch
+		}
+	}()
+	msg := readMessage(t, conn)
+	mustWriteJSON(t, conn, map[string]interface{}{
+		"type":    "Success",
+		"payload": map[string]interface{}{"message_id": msg["messageId"]},
+	})
+
+	var notifCh <-chan MutationNotification
+	select {
+	case notifCh = <-subCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for subscribe ack")
+	}
+
+	// Server streams notifications continuously until told to stop.
+	stop := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		payload := map[string]interface{}{
+			"type": "MutationNotification",
+			"payload": map[string]interface{}{
+				"collection": "orders", "event": "insert",
+				"record_ids": []string{"x"}, "timestamp": "2026-03-13T00:00:00Z",
+			},
+		}
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := conn.WriteJSON(payload); err != nil {
+				return
+			}
+		}
+	}()
+
+	// A consumer drains so most deliveries take the send branch (maximizing the
+	// window the old code raced on), then we Unsubscribe mid-stream.
+	go func() {
+		for range notifCh {
+		}
+	}()
+	time.Sleep(30 * time.Millisecond)
+	ws.Unsubscribe("orders")
+	time.Sleep(30 * time.Millisecond)
+
+	close(stop)
+	<-writerDone
+	// Reaching here without a panic means deliver-vs-close is safe.
+}


### PR DESCRIPTION
- Implemented automatic reconnection logic in WebSocketClient with exponential backoff and jitter.
- Added tokenProvider function to fetch fresh tokens on each reconnect.
- Enhanced Subscribe method to store parameters for resubscription after reconnects.
- Introduced Unsubscribe method to cleanly remove subscriptions.
- Added tests to verify reconnect behavior and token handling during reconnects.
- Removed unused Regex filter from QueryBuilder and updated related tests.
- Improved rate limit handling with synchronization to prevent data races.
- Updated README to reflect changes in query capabilities and examples.