### PR TITLE
feat: metadata pre-filter for search + client-tool keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.22.0] - 2026-06-23
+
+### Added
+
+- **`SubmitChatToolKeepalive` for in-flight client tools (resets the server-side
+  per-tool wait deadline; pairs with ekoDB#530).**
+- **Metadata pre-filter for text, vector, and hybrid search (#475).**
+  `SearchQuery` gained a `Filters` field and `SearchQueryBuilder` a
+  `Filters(filter interface{})` method carrying a canonical `QueryExpression`
+  (the same shape produced under `QueryBuilder.Build()`'s `"filter"` key). Only
+  records matching the filter are considered as candidates before ranking;
+  serialized as `filters` and omitted when unset. The `examples/` search example
+  now demonstrates a filtered search. Tests: `TestSearchQueryBuilderFilters`,
+  `TestSearchQueryBuilderFiltersOmittedWhenUnset`.
 
 ### Tests
 

--- a/chat.go
+++ b/chat.go
@@ -454,6 +454,22 @@ func (c *Client) SubmitChatToolResult(sessionID, callID string, success bool, re
 	return err
 }
 
+// SubmitChatToolKeepalive sends a liveness ping for an in-flight client tool. It is
+// NOT a result: it resets the server's per-tool wait deadline (config
+// client_tool_timeout_secs, default 60s) so a slow confirmation or a long-running
+// tool doesn't get the turn timed out mid-response. Send it periodically while the
+// tool is still working, then call SubmitChatToolResult once when it completes
+// (pairs with ekoDB#530).
+func (c *Client) SubmitChatToolKeepalive(sessionID, callID string) error {
+	body := map[string]interface{}{
+		"call_id":   callID,
+		"keepalive": true,
+	}
+
+	_, err := c.makeRequest("POST", fmt.Sprintf("/api/chat/%s/tool-result", url.PathEscape(sessionID)), body)
+	return err
+}
+
 // ExecuteToolRequest is the request body for POST /api/chat/tools/execute.
 type ExecuteToolRequest struct {
 	Tool   string                 `json:"tool"`

--- a/chat_test.go
+++ b/chat_test.go
@@ -844,6 +844,37 @@ func TestSubmitChatToolResultError(t *testing.T) {
 	}
 }
 
+func TestSubmitChatToolKeepalive(t *testing.T) {
+	server := createTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/chat/chat-123/tool-result": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("Failed to decode request body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if body["call_id"] != "call-456" {
+				t.Errorf("Expected call_id=call-456, got %v", body["call_id"])
+			}
+			if body["keepalive"] != true {
+				t.Errorf("Expected keepalive=true, got %v", body["keepalive"])
+			}
+			if _, ok := body["success"]; ok {
+				t.Errorf("Expected no success field on keepalive, got %v", body["success"])
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		},
+	})
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	err := client.SubmitChatToolKeepalive("chat-123", "call-456")
+	if err != nil {
+		t.Fatalf("SubmitChatToolKeepalive failed: %v", err)
+	}
+}
+
 // ============================================================================
 // CompactChat Tests
 // ============================================================================

--- a/client_test.go
+++ b/client_test.go
@@ -1519,6 +1519,53 @@ func TestSearchQueryBuilderExcludeFields(t *testing.T) {
 	}
 }
 
+func TestSearchQueryBuilderFilters(t *testing.T) {
+	filter := map[string]interface{}{
+		"type": "Condition",
+		"content": map[string]interface{}{
+			"field":    "category",
+			"operator": "Eq",
+			"value":    "ml",
+		},
+	}
+	query := NewSearchQueryBuilder("test query").
+		Vector([]float64{0.1, 0.2, 0.3}).
+		Filters(filter).
+		Build()
+
+	if query.Filters == nil {
+		t.Fatal("Filters not set")
+	}
+
+	// Filters must serialize under the "filters" key as the canonical shape.
+	encoded, err := json.Marshal(query)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	filtersOut, ok := decoded["filters"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("filters not present as object, got: %v", decoded["filters"])
+	}
+	if filtersOut["type"] != "Condition" {
+		t.Errorf("filters.type = %v, want Condition", filtersOut["type"])
+	}
+}
+
+func TestSearchQueryBuilderFiltersOmittedWhenUnset(t *testing.T) {
+	query := NewSearchQueryBuilder("test query").Build()
+	encoded, err := json.Marshal(query)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if strings.Contains(string(encoded), "filters") {
+		t.Errorf("filters should be omitted when unset, got: %s", encoded)
+	}
+}
+
 // ============================================================================
 // KV Find/Query Tests
 // ============================================================================

--- a/client_test.go
+++ b/client_test.go
@@ -1561,7 +1561,14 @@ func TestSearchQueryBuilderFiltersOmittedWhenUnset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal failed: %v", err)
 	}
-	if strings.Contains(string(encoded), "filters") {
+	// Unmarshal and assert the key is absent rather than scanning the raw JSON
+	// string, which would false-positive if another field's value contained
+	// the substring "filters".
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if _, present := decoded["filters"]; present {
 		t.Errorf("filters should be omitted when unset, got: %s", encoded)
 	}
 }

--- a/search.go
+++ b/search.go
@@ -41,6 +41,12 @@ type SearchQuery struct {
 	// Field projection
 	SelectFields  []string `json:"select_fields,omitempty"`
 	ExcludeFields []string `json:"exclude_fields,omitempty"`
+
+	// Metadata pre-filter for vector/hybrid search: a canonical QueryExpression
+	// (same shape as the value under QueryBuilder.Build()'s "filter" key). Only
+	// records matching the filter are considered candidates before similarity
+	// ranking.
+	Filters interface{} `json:"filters,omitempty"`
 }
 
 // SearchResult represents a single search result
@@ -194,6 +200,15 @@ func (sb *SearchQueryBuilder) SelectFields(fields []string) *SearchQueryBuilder 
 // ExcludeFields excludes specific fields from results
 func (sb *SearchQueryBuilder) ExcludeFields(fields []string) *SearchQueryBuilder {
 	sb.query.ExcludeFields = fields
+	return sb
+}
+
+// Filters sets a metadata pre-filter for vector/hybrid search. Accepts a
+// canonical QueryExpression (e.g. the value under the "filter" key produced by
+// QueryBuilder.Build()); only records matching the filter are considered as
+// candidates before similarity ranking.
+func (sb *SearchQueryBuilder) Filters(filter interface{}) *SearchQueryBuilder {
+	sb.query.Filters = filter
 	return sb
 }
 

--- a/search.go
+++ b/search.go
@@ -42,10 +42,11 @@ type SearchQuery struct {
 	SelectFields  []string `json:"select_fields,omitempty"`
 	ExcludeFields []string `json:"exclude_fields,omitempty"`
 
-	// Metadata pre-filter for vector/hybrid search: a canonical QueryExpression
-	// (same shape as the value under QueryBuilder.Build()'s "filter" key). Only
-	// records matching the filter are considered candidates before similarity
-	// ranking.
+	// Metadata pre-filter for text, vector, and hybrid search. Carries a
+	// canonical QueryExpression whose shape matches the value under
+	// QueryBuilder.Build()'s "filter" key; note this struct serializes it under
+	// the JSON key "filters". Only records matching the filter are considered
+	// candidates before ranking.
 	Filters interface{} `json:"filters,omitempty"`
 }
 
@@ -203,10 +204,11 @@ func (sb *SearchQueryBuilder) ExcludeFields(fields []string) *SearchQueryBuilder
 	return sb
 }
 
-// Filters sets a metadata pre-filter for vector/hybrid search. Accepts a
-// canonical QueryExpression (e.g. the value under the "filter" key produced by
-// QueryBuilder.Build()); only records matching the filter are considered as
-// candidates before similarity ranking.
+// Filters sets a metadata pre-filter for text, vector, and hybrid search.
+// Accepts a canonical QueryExpression whose shape matches the value under the
+// "filter" key produced by QueryBuilder.Build() (the request serializes it
+// under the "filters" key); only records matching the filter are considered as
+// candidates before ranking.
 func (sb *SearchQueryBuilder) Filters(filter interface{}) *SearchQueryBuilder {
 	sb.query.Filters = filter
 	return sb


### PR DESCRIPTION
## Summary

Two additions to the Go client:

1. **Metadata pre-filter for search** — a new `filters` field on `SearchQuery`, so only records matching a filter are considered as candidates before ranking (text, vector, and hybrid search).
2. **Client-tool keepalive** — a `SubmitChatToolKeepalive` method to keep an in-flight client-tool turn alive during slow confirmations or long-running tools.

## Metadata pre-filter

- `SearchQuery` gains a `Filters interface{}` field, serialized as `filters` and omitted when unset. It carries a canonical `QueryExpression` — the same shape produced under `QueryBuilder.Build()`'s `"filter"` key (`Eq`/`Ne`/`Gt`/`In`/`Logical`, nested paths, etc.).
- New `SearchQueryBuilder.Filters(filter interface{})` builder method.
- The `examples/` search example demonstrates a filtered search.
- Tests: `TestSearchQueryBuilderFilters` (builder wiring + serialization under the `filters` key), `TestSearchQueryBuilderFiltersOmittedWhenUnset`.

## Client-tool keepalive

- New `SubmitChatToolKeepalive(sessionID, callID string) error`. Sends a liveness ping (NOT a result) for a pending client tool on an in-flight SSE chat stream — it resets the server's per-tool wait deadline (the `client_tool_timeout_secs` setting, default 60s) so a slow human confirmation or a long-running client tool doesn't get the agent turn timed out mid-response. Send it periodically while the tool is still working, then call `SubmitChatToolResult` once when it completes.
- Test: `TestSubmitChatToolKeepalive` (asserts the request posts `keepalive: true` with the call id and no `success` field).

Pairs with server-side support for both features (tracked internally).
