### PR TITLE
feat: forward transaction_id query param on BatchInsert/BatchUpdate/BatchDelete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2026-06-27
+
+### Added
+
+- **Batch insert/update/delete now forward `transaction_id` to support
+  transactional batch writes.** `BatchInsertOptions` / `BatchUpdateOptions` /
+  `BatchDeleteOptions` already declared a `TransactionId` field, but the three
+  batch methods never sent it — so batch writes staged into an MVCC transaction
+  silently executed outside it. The field is now appended as the
+  `transaction_id` query parameter to `/api/batch/{insert,update,delete}/…` (the
+  server batch handlers already honor it), mirroring the single-record ops.
+  Additive/opt-in — callers that don't set `TransactionId` are unaffected.
+  Covered by `TestBatchOpsWithTransactionIDQueryParam`. Brings batch-transaction
+  parity with the Rust/Python/TypeScript/Kotlin clients.
+
+### Security
+
+- **`ListFunctions` / `ListUserFunctions` now percent-encode the `tags` query
+  value.** The tag list was concatenated raw into `?tags=…`, so a tag containing
+  query-reserved characters (`&`, `=`) could split into extra query parameters
+  (e.g. `a&injected=1` smuggling an `injected=1` param) and produce a malformed
+  URL. Both methods now wrap the joined value in `url.QueryEscape`. Defense in
+  depth and cross-client consistency with the matching `tags` fix in the other
+  `ekodb-client` SDKs. Covered by
+  `TestListUserFunctionsEncodesReservedCharsInTags` and
+  `TestListFunctionsEncodesReservedCharsInTags`, which assert the value
+  round-trips intact and no smuggled param leaks.
+
 ## [0.22.0] - 2026-06-23
 
 ### Added

--- a/client.go
+++ b/client.go
@@ -1029,6 +1029,11 @@ func (c *Client) BatchInsert(collection string, records []Record, opts ...BatchI
 	query := batchInsertQuery{Inserts: inserts}
 
 	path := "/api/batch/insert/" + url.PathEscape(collection)
+	if len(opts) > 0 && opts[0].TransactionId != nil {
+		params := url.Values{}
+		params.Add("transaction_id", *opts[0].TransactionId)
+		path = fmt.Sprintf("%s?%s", path, params.Encode())
+	}
 	respBody, err := c.makeRequest("POST", path, query)
 	if err != nil {
 		return nil, err
@@ -1083,6 +1088,11 @@ func (c *Client) BatchUpdate(collection string, updates map[string]Record, opts 
 	query := batchUpdateQuery{Updates: items}
 
 	path := "/api/batch/update/" + url.PathEscape(collection)
+	if len(opts) > 0 && opts[0].TransactionId != nil {
+		params := url.Values{}
+		params.Add("transaction_id", *opts[0].TransactionId)
+		path = fmt.Sprintf("%s?%s", path, params.Encode())
+	}
 	respBody, err := c.makeRequest("PUT", path, query)
 	if err != nil {
 		return nil, err
@@ -1136,6 +1146,11 @@ func (c *Client) BatchDelete(collection string, ids []string, opts ...BatchDelet
 	query := batchDeleteQuery{Deletes: deletes}
 
 	path := "/api/batch/delete/" + url.PathEscape(collection)
+	if len(opts) > 0 && opts[0].TransactionId != nil {
+		params := url.Values{}
+		params.Add("transaction_id", *opts[0].TransactionId)
+		path = fmt.Sprintf("%s?%s", path, params.Encode())
+	}
 	respBody, err := c.makeRequest("DELETE", path, query)
 	if err != nil {
 		return 0, err

--- a/client_test.go
+++ b/client_test.go
@@ -2637,6 +2637,30 @@ func TestListUserFunctionsEncodesReservedCharsInTags(t *testing.T) {
 	}
 }
 
+func TestListFunctionsEncodesReservedCharsInTags(t *testing.T) {
+	var got capturedRequest
+	server := newCapturingServer(t, &got)
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	// ListFunctions applies the same tags QueryEscape as ListUserFunctions, so
+	// a tag containing query-reserved characters must round-trip intact and not
+	// smuggle an extra query param. The capturing server's "{}" body won't
+	// unmarshal into []UserFunction, so we ignore the result and assert only on
+	// the captured query.
+	_, _ = client.ListFunctions([]string{"a&injected=1", "b"})
+
+	if got.escapedPath != "/api/functions" {
+		t.Errorf("path = %q, want /api/functions", got.escapedPath)
+	}
+	if v := got.queryValues.Get("tags"); v != "a&injected=1,b" {
+		t.Errorf("tags = %q, want %q", v, "a&injected=1,b")
+	}
+	if got.queryValues.Has("injected") {
+		t.Errorf("reserved chars leaked a smuggled query param: injected=%q", got.queryValues.Get("injected"))
+	}
+}
+
 func TestRollbackToSavepointRequestShape(t *testing.T) {
 	var got capturedRequest
 	server := newCapturingServer(t, &got)

--- a/client_test.go
+++ b/client_test.go
@@ -2853,6 +2853,65 @@ func TestFindWithTransactionIDQueryParam(t *testing.T) {
 	}
 }
 
+// Batch ops must forward transaction_id as a query param so a caller can stage
+// batch writes into an MVCC transaction (server batch handlers read
+// query_params.transaction_id). Previously the field was declared on the
+// Batch*Options structs but never sent — a silent no-op.
+func TestBatchOpsWithTransactionIDQueryParam(t *testing.T) {
+	txID := "tx_batch"
+
+	t.Run("BatchInsert", func(t *testing.T) {
+		var got capturedRequest
+		server := newCapturingServer(t, &got)
+		defer server.Close()
+		client := createTestClient(t, server)
+		if _, err := client.BatchInsert("users", []Record{{"name": "a"}},
+			BatchInsertOptions{TransactionId: &txID}); err != nil {
+			t.Fatalf("BatchInsert failed: %v", err)
+		}
+		if got.escapedPath != "/api/batch/insert/users" {
+			t.Errorf("path = %q", got.escapedPath)
+		}
+		if v := got.queryValues.Get("transaction_id"); v != txID {
+			t.Errorf("transaction_id = %q, want %q", v, txID)
+		}
+	})
+
+	t.Run("BatchUpdate", func(t *testing.T) {
+		var got capturedRequest
+		server := newCapturingServer(t, &got)
+		defer server.Close()
+		client := createTestClient(t, server)
+		if _, err := client.BatchUpdate("users", map[string]Record{"id1": {"name": "b"}},
+			BatchUpdateOptions{TransactionId: &txID}); err != nil {
+			t.Fatalf("BatchUpdate failed: %v", err)
+		}
+		if got.escapedPath != "/api/batch/update/users" {
+			t.Errorf("path = %q", got.escapedPath)
+		}
+		if v := got.queryValues.Get("transaction_id"); v != txID {
+			t.Errorf("transaction_id = %q, want %q", v, txID)
+		}
+	})
+
+	t.Run("BatchDelete", func(t *testing.T) {
+		var got capturedRequest
+		server := newCapturingServer(t, &got)
+		defer server.Close()
+		client := createTestClient(t, server)
+		if _, err := client.BatchDelete("users", []string{"id1"},
+			BatchDeleteOptions{TransactionId: &txID}); err != nil {
+			t.Fatalf("BatchDelete failed: %v", err)
+		}
+		if got.escapedPath != "/api/batch/delete/users" {
+			t.Errorf("path = %q", got.escapedPath)
+		}
+		if v := got.queryValues.Get("transaction_id"); v != txID {
+			t.Errorf("transaction_id = %q, want %q", v, txID)
+		}
+	})
+}
+
 func TestFindWithoutTransactionIDHasNoQueryParam(t *testing.T) {
 	var got capturedRequest
 	server := newCapturingServer(t, &got)

--- a/client_test.go
+++ b/client_test.go
@@ -2613,6 +2613,30 @@ func TestCreateSavepointRequestShape(t *testing.T) {
 	}
 }
 
+func TestListUserFunctionsEncodesReservedCharsInTags(t *testing.T) {
+	var got capturedRequest
+	server := newCapturingServer(t, &got)
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	// A tag containing query-reserved characters must be percent-encoded, not
+	// concatenated raw into ?tags=... (which would split into extra query
+	// params). The capturing server's "{}" body won't unmarshal into
+	// []UserFunction, so we ignore the result and assert only on the captured
+	// query — which is recorded before the response is written.
+	_, _ = client.ListUserFunctions([]string{"a&injected=1", "b"})
+
+	if got.escapedPath != "/api/functions" {
+		t.Errorf("path = %q, want /api/functions", got.escapedPath)
+	}
+	if v := got.queryValues.Get("tags"); v != "a&injected=1,b" {
+		t.Errorf("tags = %q, want %q", v, "a&injected=1,b")
+	}
+	if got.queryValues.Has("injected") {
+		t.Errorf("reserved chars leaked a smuggled query param: injected=%q", got.queryValues.Get("injected"))
+	}
+}
+
 func TestRollbackToSavepointRequestShape(t *testing.T) {
 	var got capturedRequest
 	server := newCapturingServer(t, &got)

--- a/functions.go
+++ b/functions.go
@@ -1310,12 +1310,14 @@ func (c *Client) GetFunction(id string) (*UserFunction, error) {
 
 // ListFunctions lists all functions, optionally filtered by tags
 func (c *Client) ListFunctions(tags []string) ([]UserFunction, error) {
-	url := "/api/functions"
+	reqURL := "/api/functions"
 	if len(tags) > 0 {
-		url += "?tags=" + joinStrings(tags, ",")
+		// QueryEscape encodes the value (`&`/`=`/`,`), so a tag containing
+		// query-reserved characters can't smuggle extra query params.
+		reqURL += "?tags=" + url.QueryEscape(joinStrings(tags, ","))
 	}
 
-	respBody, err := c.makeRequest("GET", url, nil)
+	respBody, err := c.makeRequest("GET", reqURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1411,12 +1413,14 @@ func (c *Client) GetUserFunction(label string) (*UserFunction, error) {
 
 // ListUserFunctions lists all user functions, optionally filtered by tags
 func (c *Client) ListUserFunctions(tags []string) ([]UserFunction, error) {
-	url := "/api/functions"
+	reqURL := "/api/functions"
 	if len(tags) > 0 {
-		url += "?tags=" + joinStrings(tags, ",")
+		// QueryEscape encodes the value (`&`/`=`/`,`), so a tag containing
+		// query-reserved characters can't smuggle extra query params.
+		reqURL += "?tags=" + url.QueryEscape(joinStrings(tags, ","))
 	}
 
-	respBody, err := c.makeRequest("GET", url, nil)
+	respBody, err := c.makeRequest("GET", reqURL, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Forwards `transaction_id` as a query parameter on `BatchInsert`, `BatchUpdate`, and
`BatchDelete`, so a caller can stage batch writes into an MVCC transaction
(begin → stage → commit) instead of committing each batch immediately.

The `TransactionId` field already existed on `BatchInsertOptions` / `BatchUpdateOptions` /
`BatchDeleteOptions`, but it was **declared and never sent** — a silent no-op. This wires it
through to the request URL, matching how the single-record write operations already carry
`transaction_id`.

## Changes

- `client.go` — when `opts[0].TransactionId` is set, each batch operation appends
  `transaction_id` via `url.Values` and `params.Encode()` (so the value is URL-encoded), on
  `/api/batch/{insert,update,delete}/{collection}`. Additive and opt-in: existing callers that
  pass no transaction id are unchanged.
- `client_test.go` — `TestBatchOpsWithTransactionIDQueryParam` with subtests for
  `BatchInsert` / `BatchUpdate` / `BatchDelete`, each asserting the request path is correct and
  the `transaction_id` query value is sent as supplied.

## Why

The ekoDB server batch endpoints read `transaction_id` from the query parameters to route the
batch into a named MVCC transaction. Without forwarding it, the option silently did nothing and
batch writes could not participate in a transaction.

## Testing

- `make test` (Go client unit tests) — `TestBatchOpsWithTransactionIDQueryParam` passes for all
  three batch operations.

## Notes

Brings the Go client to parity with the batch-transaction support in the other `ekodb-client`
SDKs. Server-side support is already in place.
