### PR TITLE
feat: Add linting to CI and ensure consistent linting with pinned gol…

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,9 +48,12 @@ jobs:
       - name: Test summary
         if: always()
         run: |
+          # Count test functions from source so the number is never hardcoded /
+          # stale (a `go test` run of *_test.go).
+          count=$(grep -rhE '^func Test[A-Z]' --include='*_test.go' . | wc -l | tr -d ' ')
           echo "## Go Client Unit Tests" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "72 tests covering:" >> $GITHUB_STEP_SUMMARY
+          echo "$count tests covering:" >> $GITHUB_STEP_SUMMARY
           echo "- Client configuration and operations" >> $GITHUB_STEP_SUMMARY
           echo "- QueryBuilder fluent API" >> $GITHUB_STEP_SUMMARY
           echo "- HTTP mocking and error handling" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
       # Runs the exact same target developers run locally (`make lint`), which
       # installs the pinned golangci-lint (GOLANGCI_VERSION in the Makefile) and
       # runs it gating. Single source of truth = no local/CI drift.
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
 
       # -race matches the local `make test` target so a data race can't pass
       # locally and fail (or vice versa) in CI.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,21 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      # Runs the exact same target developers run locally (`make lint`), which
+      # installs the pinned golangci-lint (GOLANGCI_VERSION in the Makefile) and
+      # runs it gating. Single source of truth = no local/CI drift.
+      - name: Lint
+        run: make lint
+
   go-tests:
     name: Go Client Tests
     runs-on: ubuntu-latest
@@ -25,8 +40,10 @@ jobs:
         with:
           go-version: '1.22'
 
+      # -race matches the local `make test` target so a data race can't pass
+      # locally and fail (or vice versa) in CI.
       - name: Run tests
-        run: go test -v ./...
+        run: go test -v -race ./...
 
       - name: Test summary
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2026-07-07
+
+### Infrastructure
+
+- **golangci-lint bootstrap hardened.** The install directory is now derived
+  honoring `GOBIN`, falling back to the first `GOPATH` entry, so a multi-entry
+  `GOPATH` no longer expands to an invalid `/a:/b/bin` path. `install.sh` is
+  fetched from the pinned `$(GOLANGCI_VERSION)` tag instead of `master` for a
+  reproducible bootstrap, and a post-install check fails the target if
+  `curl | sh` silently produced no binary.
+
+- **CI now lints, and local/CI lint run identical commands.** CI
+  (`unit-tests.yml`) previously ran only `go test` with no lint job, and local
+  `make lint` used an unpinned golangci-lint (`@latest`) that silently no-op'd
+  if it wasn't installed. Added a gating `lint` job that runs `make lint`,
+  pinned golangci-lint to `v2.11.4` in the Makefile (installed on demand), and
+  made `make lint` gate with the same flags as the other Go repos. This surfaced
+  (and fixed) 5 previously uncaught `errcheck` findings in production code
+  (`chat.go`, `client.go`: unchecked `resp.Body.Close()`). The test job now runs
+  with `-race` to match the local `make test` target.
+
+- **Test and example counts are no longer hardcoded.** The CI "Test summary"
+  step hardcoded `72 tests` (the suite had grown to 417); it now counts
+  `func Test` from source at run time. The README's "Examples Repository" line
+  hardcoded
+  `308 examples across all 6 languages (257 client library + 51 direct API)` — a
+  mirror of the ekodb-client example inventory that this standalone repo cannot
+  see and so drifts silently. That line now describes the examples by language
+  and relies on the link to carry the reader to the live source, with no copied
+  numbers.
+
 ## [0.23.1] - 2026-07-05
 
 ### Infrastructure

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ JET := "                    $(MAGENTA)●$(RESET)\n                    $(PURPLE)
 # ASCII Banner for ekoDB (matches CLI banner)
 BANNER := "$(BOLD) ██████═╗ ██╗  ██╗  ██████╗  ████████╗ ████████╗$(RESET)\n$(BOLD)██╔═══██╝ ██║ ██╔╝ ██╔═══██╗  ██╔═══██║ ██╔═══██╗$(RESET)\n$(BOLD)████████╗ █████╔╝  ██║   ██║  ██║   ██║████████╔╝$(RESET)\n$(BOLD)██╔═════╝ ██╔═██╗  ██║   ██║  ██║   ██║ ██╔═══██╗$(RESET)\n$(BOLD)████████╗ ██║  ██╗ ╚██████╔╝ ████████║ ████████╔╝$(RESET)\n$(BOLD)╚═══════╝ ╚═╝  ╚═╝  ╚═════╝  ╚═══════╝ ╚═══════╝$(RESET)"
 
-.PHONY: all build test test-verbose test-coverage clean fmt fmt-go fmt-md fmt-check format lint vet mod-tidy mod-verify mod-download install help setup deps-check deps-update publish bump-version check-ready examples pre-commit ensure-hooks version info
+.PHONY: all build test test-verbose test-coverage clean fmt fmt-go fmt-md fmt-check format lint lint-fix ensure-golangci-lint vet mod-tidy mod-verify mod-download install help setup deps-check deps-update publish bump-version check-ready examples pre-commit ensure-hooks version info
 
 # Language Sub-Banner
 GO_BANNER := \
@@ -175,18 +175,23 @@ fmt-check:
 	@echo "✅ $(GREEN)All files are properly formatted!$(RESET)"
 
 # Run golangci-lint
-GOLANGCI_LINT := $(shell command -v golangci-lint 2>/dev/null || echo "$(shell go env GOPATH)/bin/golangci-lint")
+# golangci-lint version — pinned so local `make lint` and CI run the EXACT same
+# linter. CI (unit-tests.yml) calls `make lint`, so this is the single source of
+# truth. Keep flags identical to the other Go repos (currentcs, wavescd).
+GOLANGCI_VERSION ?= v2.11.4
+GOLANGCI_FLAGS := run --timeout=5m --tests=false --max-issues-per-linter=0 --max-same-issues=0
 
-lint:
-	@echo "🔬 $(CYAN)Running golangci-lint...$(RESET)"
-	@if [ -x "$(GOLANGCI_LINT)" ]; then \
-		$(GOLANGCI_LINT) run ./...; \
-		echo "✅ $(GREEN)Linting complete!$(RESET)"; \
-	else \
-		echo "$(YELLOW)⚠️  golangci-lint not found$(RESET)"; \
-		echo "$(YELLOW)Install with: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest$(RESET)"; \
-		echo "$(YELLOW)Or visit: https://golangci-lint.run/usage/install/$(RESET)"; \
+ensure-golangci-lint: ## Install the pinned golangci-lint if missing or a different version
+	@BIN=$$(go env GOPATH)/bin; VER="$(patsubst v%,%,$(GOLANGCI_VERSION))"; \
+	if ! "$$BIN/golangci-lint" version 2>/dev/null | grep -q "$$VER"; then \
+		echo "📦 $(YELLOW)Installing golangci-lint $(GOLANGCI_VERSION)...$(RESET)"; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$$BIN" $(GOLANGCI_VERSION); \
 	fi
+
+lint: ensure-golangci-lint ## Run linter (gating; pinned version, identical to CI)
+	@echo "🔬 $(CYAN)Running golangci-lint $(GOLANGCI_VERSION)...$(RESET)"
+	@$$(go env GOPATH)/bin/golangci-lint $(GOLANGCI_FLAGS) ./...
+	@echo "✅ $(GREEN)Lint passed!$(RESET)"
 
 # Run go vet
 vet:

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ fmt-check:
 # Run golangci-lint
 # golangci-lint version — pinned so local `make lint` and CI run the EXACT same
 # linter. CI (unit-tests.yml) calls `make lint`, so this is the single source of
-# truth. Keep flags identical to the other Go repos (currentcs, wavescd).
+# truth. Keep the flags identical across our Go repos.
 GOLANGCI_VERSION ?= v2.11.4
 GOLANGCI_FLAGS := run --timeout=5m --tests=false --max-issues-per-linter=0 --max-same-issues=0
 # golangci-lint install dir: honor GOBIN, else the FIRST GOPATH entry's bin (a

--- a/Makefile
+++ b/Makefile
@@ -180,22 +180,27 @@ fmt-check:
 # truth. Keep flags identical to the other Go repos (currentcs, wavescd).
 GOLANGCI_VERSION ?= v2.11.4
 GOLANGCI_FLAGS := run --timeout=5m --tests=false --max-issues-per-linter=0 --max-same-issues=0
+# golangci-lint install dir: honor GOBIN, else the FIRST GOPATH entry's bin (a
+# multi-entry GOPATH like /a:/b would otherwise expand to an invalid /a:/b/bin).
+GOLANGCI_BIN_DIR := $(or $(shell go env GOBIN),$(firstword $(subst :, ,$(shell go env GOPATH)))/bin)
+GOLANGCI_BIN := $(GOLANGCI_BIN_DIR)/golangci-lint
 
 ensure-golangci-lint: ## Install the pinned golangci-lint if missing or a different version
-	@BIN=$$(go env GOPATH)/bin; VER="$(patsubst v%,%,$(GOLANGCI_VERSION))"; \
+	@BIN="$(GOLANGCI_BIN_DIR)"; VER="$(patsubst v%,%,$(GOLANGCI_VERSION))"; \
 	if [ ! -x "$$BIN/golangci-lint" ] || ! "$$BIN/golangci-lint" version 2>/dev/null | grep -qwF "$$VER"; then \
 		echo "📦 $(YELLOW)Installing golangci-lint $(GOLANGCI_VERSION)...$(RESET)"; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$$BIN" $(GOLANGCI_VERSION); \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_VERSION)/install.sh | sh -s -- -b "$$BIN" $(GOLANGCI_VERSION); \
+		[ -x "$$BIN/golangci-lint" ] || { echo "❌ $(RED)golangci-lint install failed$(RESET)"; exit 1; }; \
 	fi
 
 lint: ensure-golangci-lint ## Run linter (gating; pinned version, identical to CI)
 	@echo "🔬 $(CYAN)Running golangci-lint $(GOLANGCI_VERSION)...$(RESET)"
-	@$$(go env GOPATH)/bin/golangci-lint $(GOLANGCI_FLAGS) ./...
+	@$(GOLANGCI_BIN) $(GOLANGCI_FLAGS) ./...
 	@echo "✅ $(GREEN)Lint passed!$(RESET)"
 
 lint-fix: ensure-golangci-lint ## Run linter with autofix (same pinned version as lint)
 	@echo "🔬 $(CYAN)Running golangci-lint --fix $(GOLANGCI_VERSION)...$(RESET)"
-	@$$(go env GOPATH)/bin/golangci-lint $(GOLANGCI_FLAGS) --fix ./...
+	@$(GOLANGCI_BIN) $(GOLANGCI_FLAGS) --fix ./...
 	@echo "✅ $(GREEN)Lint fixes applied!$(RESET)"
 
 # Run go vet

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ GOLANGCI_FLAGS := run --timeout=5m --tests=false --max-issues-per-linter=0 --max
 
 ensure-golangci-lint: ## Install the pinned golangci-lint if missing or a different version
 	@BIN=$$(go env GOPATH)/bin; VER="$(patsubst v%,%,$(GOLANGCI_VERSION))"; \
-	if ! "$$BIN/golangci-lint" version 2>/dev/null | grep -q "$$VER"; then \
+	if ! "$$BIN/golangci-lint" version 2>/dev/null | grep -qwF "$$VER"; then \
 		echo "📦 $(YELLOW)Installing golangci-lint $(GOLANGCI_VERSION)...$(RESET)"; \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$$BIN" $(GOLANGCI_VERSION); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,11 @@ lint: ensure-golangci-lint ## Run linter (gating; pinned version, identical to C
 	@$$(go env GOPATH)/bin/golangci-lint $(GOLANGCI_FLAGS) ./...
 	@echo "✅ $(GREEN)Lint passed!$(RESET)"
 
+lint-fix: ensure-golangci-lint ## Run linter with autofix (same pinned version as lint)
+	@echo "🔬 $(CYAN)Running golangci-lint --fix $(GOLANGCI_VERSION)...$(RESET)"
+	@$$(go env GOPATH)/bin/golangci-lint $(GOLANGCI_FLAGS) --fix ./...
+	@echo "✅ $(GREEN)Lint fixes applied!$(RESET)"
+
 # Run go vet
 vet:
 	@echo "🔬 $(CYAN)Running go vet...$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ GOLANGCI_FLAGS := run --timeout=5m --tests=false --max-issues-per-linter=0 --max
 
 ensure-golangci-lint: ## Install the pinned golangci-lint if missing or a different version
 	@BIN=$$(go env GOPATH)/bin; VER="$(patsubst v%,%,$(GOLANGCI_VERSION))"; \
-	if ! "$$BIN/golangci-lint" version 2>/dev/null | grep -qwF "$$VER"; then \
+	if [ ! -x "$$BIN/golangci-lint" ] || ! "$$BIN/golangci-lint" version 2>/dev/null | grep -qwF "$$VER"; then \
 		echo "📦 $(YELLOW)Installing golangci-lint $(GOLANGCI_VERSION)...$(RESET)"; \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$$BIN" $(GOLANGCI_VERSION); \
 	fi

--- a/README.md
+++ b/README.md
@@ -582,7 +582,8 @@ go run client_simple_crud.go
 - **[API Reference](https://pkg.go.dev/github.com/ekoDB/ekodb-client-go)** - Go
   package documentation
 - **[Examples Repository](https://github.com/ekoDB/ekodb-client/tree/main/examples)** -
-  308 examples across all 6 languages (257 client library + 51 direct API)
+  runnable client-library and direct-API examples across every supported
+  language (Rust, Python, Go, TypeScript, JavaScript, Kotlin)
 
 ## 🗺️ Roadmap
 

--- a/chat.go
+++ b/chat.go
@@ -318,7 +318,7 @@ func (c *Client) RawCompletionStream(request RawCompletionRequest) (*RawCompleti
 	if err != nil {
 		return nil, fmt.Errorf("SSE request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
@@ -391,7 +391,7 @@ func (c *Client) RawCompletionStreamWithProgress(request RawCompletionRequest, o
 	if err != nil {
 		return nil, fmt.Errorf("SSE request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
@@ -871,14 +871,14 @@ func (c *Client) ChatMessageStream(ctx context.Context, sessionID string, reques
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("SSE chat message stream failed (%d): %s", resp.StatusCode, string(respBody))
 	}
 
 	ch := make(chan ChatStreamEvent, 128)
 
 	go func() {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		defer close(ch)
 
 		// send delivers an event but never blocks forever: if the consumer stops
@@ -1014,7 +1014,7 @@ func (c *Client) SubscribeSSE(ctx context.Context, collection string, opts *Subs
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("SSE subscribe failed (%d): %s", resp.StatusCode, string(respBody))
 	}
 
@@ -1022,7 +1022,7 @@ func (c *Client) SubscribeSSE(ctx context.Context, collection string, opts *Subs
 	errCh := make(chan error, 1)
 
 	go func() {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		defer close(ch)
 		defer close(errCh)
 

--- a/client.go
+++ b/client.go
@@ -240,7 +240,7 @@ func (c *Client) refreshTokenIfStale(staleToken string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
@@ -444,7 +444,7 @@ func (c *Client) makeRequestWithRetry(method, path string, data interface{}, att
 		}
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
…angci-lint version; fix unchecked response body closes

## What & why

Adds a CI lint gate and pins the lint tooling so a clean local run and a green CI run mean the same thing. `Refs #55`

- CI now runs the same `make lint` developers run locally.
- golangci-lint is pinned to a single version (installed on demand by `ensure-golangci-lint`), so local and CI evaluate the identical linter set.
- Both CI jobs use `go-version-file: go.mod`, so the toolchain follows the module's declared Go version instead of a hardcoded pin that could drift.
- Added a `make lint-fix` autofix target.
- Fixed the unchecked `resp.Body.Close()` errcheck findings the gate surfaced.

## Reviewer checklist (before merge)

- [ ] **Data contract traced end to end:** every field/value flows intact
      through every layer that transforms it (e.g. handler, serializer,
      transport, client mapping, UI); no layer silently drops or renames it.
- [ ] Every layer that reshapes a payload has a test asserting the **whole**
      contract (all fields), not a subset. Prefer one shared builder over
      duplicated hand-built objects so they cannot drift.
- [ ] **Real path verified, not just unit tests:** drove the running code,
      captured the real payload at the boundary, confirmed the observable
      output. Green units plus approved reviews are not proof it works.
- [ ] No dead, speculative, or unwired code; no "known gaps".
- [ ] Tests cover happy, error, and boundary paths.
- [ ] Docs updated; CHANGELOG under `[Unreleased]` (committed at release).
- [ ] Cross-surface parity where relevant (server and all clients, CLI and GUI,
      code and docs).

## Verification evidence

`make lint` passes with the pinned golangci-lint; `go build ./...` and `go test -race ./...` are clean; both CI jobs resolve the Go toolchain from `go.mod`.

