### PR TITLE
feat: degraded-tolerant health API (HealthStatus, ParseHealthStatus, reachable-only Health)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2026-07-14
+
+### Added
+
+- **`Client.HealthStatus() (*HealthStatus, error)`: structured,
+  degraded-tolerant health.** Returns a snapshot
+  `{Reachable, Status, IntegrityOK, Detail}` parsed from `/api/health`, where
+  `Status` is a typed `HealthState` (`HealthOK` / `HealthDegraded`). Its JSON
+  form is a safe summary (`reachable` / `status` / `integrity_ok`); `Detail`
+  (the full admin body, including internal metrics and collection names) is
+  excluded from JSON (`json:"-"`) so surfacing the snapshot cannot leak
+  internals, and is read in-process when the raw body is needed. An error is
+  returned **only** when the server is unreachable (connection refused, timeout,
+  non-2xx, unparseable body); a `degraded` HTTP-200 response is a successful
+  result with `Status == HealthDegraded`, not an error. This is the canonical
+  way for consumers to distinguish _reachable_ (liveness) from _ok vs degraded_
+  (readiness). A missing/odd `status` field fails safe to `HealthDegraded` so
+  readiness is never falsely reported as ok. When unreachable it returns a
+  **non-nil** snapshot with `Reachable == false` and `Status == HealthUnknown`
+  alongside the error, so the value is always safe to read and serializes
+  coherently (no empty status). `IntegrityOK` is read from either the public
+  `integrity_ok` field or the admin `integrity.healthy` field, so it is correct
+  for both response shapes.
+
+- **`HealthState` typed enum with `HealthOK` / `HealthDegraded` /
+  `HealthUnknown` constants** for comparing `HealthStatus.Status` type-safely
+  instead of against bare literals. `HealthUnknown` is the status of an
+  unreachable/unparseable snapshot.
+
+- **`ParseHealthStatus(body []byte) (*HealthStatus, error)`**: the exported,
+  standalone interpreter of an `/api/health` body, reused by `HealthStatus()`
+  and by non-client probes (e.g. a service that GETs `/api/health` with its own
+  HTTP client for circuit-breaking) so every consumer reads health through the
+  exact same contract. A parseable body yields a `Reachable` snapshot; an
+  unparseable body yields a non-nil snapshot with `Reachable == false` plus an
+  error.
+
+### Changed
+
+- **`Client.Health()` is now reachable-only (behavior change).** It previously
+  returned an error whenever the server's `/api/health` body was not
+  `status == "ok"`, which conflated liveness with readiness and caused callers
+  to treat a _degraded-but-serving_ ekoDB as down (blocking startup). `Health()`
+  now returns nil whenever the server responds (including when it reports
+  `degraded`) and errors only when unreachable. Use `HealthStatus()` for the
+  `ok` vs `degraded` distinction. The ekoDB server intentionally returns HTTP
+  200 while degraded so liveness probes don't restart a recoverable instance.
+
 ## [0.24.0] - 2026-07-07
 
 ### Infrastructure

--- a/client.go
+++ b/client.go
@@ -1649,14 +1649,15 @@ const (
 	HealthUnknown HealthState = "unknown"
 )
 
-// HealthStatus is a snapshot of an ekoDB /api/health probe. It is safe to
-// serialize (all fields carry JSON tags) so a consumer can surface it directly.
+// HealthStatus is a snapshot of an ekoDB /api/health probe. Its JSON form is a
+// safe summary (reachable/status/integrity_ok); Detail is excluded (json:"-")
+// so a consumer can surface the snapshot without leaking the internal body.
 //
 // It is degraded-tolerant: a reachable server that reports degraded is a
 // successful result (err == nil) with Status == HealthDegraded, NOT an error.
 // When the server is unreachable (connection refused, timeout, non-2xx, or an
-// unparseable body) a non-nil snapshot with Reachable == false is returned
-// alongside the error.
+// unparseable body) a non-nil snapshot with Reachable == false and
+// Status == HealthUnknown is returned alongside the error.
 //
 // Consumers MUST base connection/liveness decisions on Reachable (or err == nil)
 // and treat degraded as a warning, never as a fatal or reconnect trigger. The
@@ -1664,7 +1665,7 @@ const (
 // probes do not restart a degraded-but-recoverable instance.
 type HealthStatus struct {
 	Reachable   bool        `json:"reachable"`    // a valid /api/health response came back
-	Status      HealthState `json:"status"`       // HealthOK | HealthDegraded (unknown/missing -> HealthDegraded)
+	Status      HealthState `json:"status"`       // HealthOK | HealthDegraded | HealthUnknown; a missing/odd status on a reachable body -> HealthDegraded
 	IntegrityOK bool        `json:"integrity_ok"` // body integrity_ok (public) or integrity.healthy (admin)
 	// Detail is the full parsed body (admin responses include internal metrics
 	// and collection names). It is NOT serialized (json:"-") so surfacing the

--- a/client.go
+++ b/client.go
@@ -1663,10 +1663,14 @@ const (
 // ekoDB server intentionally returns HTTP 200 while degraded so that liveness
 // probes do not restart a degraded-but-recoverable instance.
 type HealthStatus struct {
-	Reachable   bool                   `json:"reachable"`        // a valid /api/health response came back
-	Status      HealthState            `json:"status"`           // HealthOK | HealthDegraded (unknown/missing -> HealthDegraded)
-	IntegrityOK bool                   `json:"integrity_ok"`     // body integrity_ok (public) or integrity.healthy (admin)
-	Detail      map[string]interface{} `json:"detail,omitempty"` // full parsed body (admin fields when present)
+	Reachable   bool        `json:"reachable"`    // a valid /api/health response came back
+	Status      HealthState `json:"status"`       // HealthOK | HealthDegraded (unknown/missing -> HealthDegraded)
+	IntegrityOK bool        `json:"integrity_ok"` // body integrity_ok (public) or integrity.healthy (admin)
+	// Detail is the full parsed body (admin responses include internal metrics
+	// and collection names). It is NOT serialized (json:"-") so surfacing the
+	// snapshot can't leak internals; read it in-process when you need the raw
+	// body.
+	Detail map[string]interface{} `json:"-"`
 }
 
 // ParseHealthStatus interprets a raw /api/health response body per the health

--- a/client.go
+++ b/client.go
@@ -1634,6 +1634,13 @@ func (c *Client) RestoreCollection(collection string) (int, error) {
 	return result.RecordsRestored, nil
 }
 
+// HealthOK and HealthDegraded are the possible HealthStatus.Status values.
+// Consumers should compare against these constants rather than bare literals.
+const (
+	HealthOK       = "ok"
+	HealthDegraded = "degraded"
+)
+
 // HealthStatus describes the result of an ekoDB /api/health probe.
 //
 // It is degraded-tolerant: a reachable server that reports "degraded" is a
@@ -1648,7 +1655,7 @@ func (c *Client) RestoreCollection(collection string) (int, error) {
 type HealthStatus struct {
 	Reachable   bool                   // a valid /api/health response came back
 	Status      string                 // "ok" | "degraded" (unknown/missing -> "degraded")
-	IntegrityOK bool                   // body.integrity_ok
+	IntegrityOK bool                   // body integrity_ok (public) or integrity.healthy (admin)
 	Detail      map[string]interface{} // full parsed body (admin fields when present)
 }
 
@@ -1668,14 +1675,22 @@ func ParseHealthStatus(body []byte) (*HealthStatus, error) {
 		return nil, fmt.Errorf("health check: unparseable response: %w", err)
 	}
 
-	// Reachable. Default Status to "degraded" so a missing/odd status field
-	// fails safe (readiness withheld) rather than falsely reading as "ok".
-	hs := &HealthStatus{Reachable: true, Status: "degraded", Detail: result}
+	// Reachable. Default Status to degraded so a missing/odd status field fails
+	// safe (readiness withheld) rather than falsely reading as ok.
+	hs := &HealthStatus{Reachable: true, Status: HealthDegraded, Detail: result}
 	if s, ok := result["status"].(string); ok && s != "" {
 		hs.Status = s
 	}
+	// Integrity is reported two ways: the public response uses a top-level
+	// integrity_ok bool; the admin response nests it as integrity.healthy (and
+	// omits integrity_ok). Read whichever is present so IntegrityOK is correct
+	// for both.
 	if b, ok := result["integrity_ok"].(bool); ok {
 		hs.IntegrityOK = b
+	} else if integ, ok := result["integrity"].(map[string]interface{}); ok {
+		if healthy, ok := integ["healthy"].(bool); ok {
+			hs.IntegrityOK = healthy
+		}
 	}
 	return hs, nil
 }

--- a/client.go
+++ b/client.go
@@ -1638,11 +1638,11 @@ func (c *Client) RestoreCollection(collection string) (int, error) {
 //
 // It is degraded-tolerant: a reachable server that reports "degraded" is a
 // successful result (err == nil) with Status == "degraded", NOT an error. An
-// error is returned only when the server is unreachable (connection refused,
-// timeout, non-2xx, or an unparseable body).
+// error (with a nil *HealthStatus) is returned only when the server is
+// unreachable (connection refused, timeout, non-2xx, or an unparseable body).
 //
-// Consumers MUST base connection/liveness decisions on Reachable (err == nil)
-// and treat "degraded" as a warning — never as a fatal or reconnect trigger.
+// Consumers MUST base connection/liveness decisions on err == nil and treat
+// "degraded" as a warning, never as a fatal or reconnect trigger.
 // The ekoDB server intentionally returns HTTP 200 while degraded so that
 // liveness probes do not restart a degraded-but-recoverable instance.
 type HealthStatus struct {
@@ -1658,14 +1658,14 @@ type HealthStatus struct {
 // /api/health with its own HTTP client for circuit-breaking) so every consumer
 // reads health identically.
 //
-// A parseable body is Reachable with its reported Status (a missing/odd status
-// fails safe to "degraded"). An unparseable body returns an error and
-// Reachable=false.
+// A parseable body yields a non-nil, Reachable HealthStatus with its reported
+// Status (a missing/odd status fails safe to "degraded"). An unparseable body
+// yields (nil, error).
 func ParseHealthStatus(body []byte) (*HealthStatus, error) {
 	var result map[string]interface{}
 	// Always use JSON for the health endpoint.
 	if err := json.Unmarshal(body, &result); err != nil {
-		return &HealthStatus{Reachable: false}, fmt.Errorf("health check: unparseable response: %w", err)
+		return nil, fmt.Errorf("health check: unparseable response: %w", err)
 	}
 
 	// Reachable. Default Status to "degraded" so a missing/odd status field
@@ -1685,7 +1685,7 @@ func ParseHealthStatus(body []byte) (*HealthStatus, error) {
 func (c *Client) HealthStatus() (*HealthStatus, error) {
 	respBody, err := c.makeRequest("GET", "/api/health", nil)
 	if err != nil {
-		return &HealthStatus{Reachable: false}, err
+		return nil, err
 	}
 	return ParseHealthStatus(respBody)
 }

--- a/client.go
+++ b/client.go
@@ -1634,29 +1634,34 @@ func (c *Client) RestoreCollection(collection string) (int, error) {
 	return result.RecordsRestored, nil
 }
 
+// HealthState is a health status value reported by ekoDB's /api/health.
+type HealthState string
+
 // HealthOK and HealthDegraded are the possible HealthStatus.Status values.
 // Consumers should compare against these constants rather than bare literals.
 const (
-	HealthOK       = "ok"
-	HealthDegraded = "degraded"
+	HealthOK       HealthState = "ok"
+	HealthDegraded HealthState = "degraded"
 )
 
-// HealthStatus describes the result of an ekoDB /api/health probe.
+// HealthStatus is a snapshot of an ekoDB /api/health probe. It is safe to
+// serialize (all fields carry JSON tags) so a consumer can surface it directly.
 //
-// It is degraded-tolerant: a reachable server that reports "degraded" is a
-// successful result (err == nil) with Status == "degraded", NOT an error. An
-// error (with a nil *HealthStatus) is returned only when the server is
-// unreachable (connection refused, timeout, non-2xx, or an unparseable body).
+// It is degraded-tolerant: a reachable server that reports degraded is a
+// successful result (err == nil) with Status == HealthDegraded, NOT an error.
+// When the server is unreachable (connection refused, timeout, non-2xx, or an
+// unparseable body) a non-nil snapshot with Reachable == false is returned
+// alongside the error.
 //
-// Consumers MUST base connection/liveness decisions on err == nil and treat
-// "degraded" as a warning, never as a fatal or reconnect trigger.
-// The ekoDB server intentionally returns HTTP 200 while degraded so that
-// liveness probes do not restart a degraded-but-recoverable instance.
+// Consumers MUST base connection/liveness decisions on Reachable (or err == nil)
+// and treat degraded as a warning, never as a fatal or reconnect trigger. The
+// ekoDB server intentionally returns HTTP 200 while degraded so that liveness
+// probes do not restart a degraded-but-recoverable instance.
 type HealthStatus struct {
-	Reachable   bool                   // a valid /api/health response came back
-	Status      string                 // "ok" | "degraded" (unknown/missing -> "degraded")
-	IntegrityOK bool                   // body integrity_ok (public) or integrity.healthy (admin)
-	Detail      map[string]interface{} // full parsed body (admin fields when present)
+	Reachable   bool                   `json:"reachable"`        // a valid /api/health response came back
+	Status      HealthState            `json:"status"`           // HealthOK | HealthDegraded (unknown/missing -> HealthDegraded)
+	IntegrityOK bool                   `json:"integrity_ok"`     // body integrity_ok (public) or integrity.healthy (admin)
+	Detail      map[string]interface{} `json:"detail,omitempty"` // full parsed body (admin fields when present)
 }
 
 // ParseHealthStatus interprets a raw /api/health response body per the health
@@ -1666,20 +1671,20 @@ type HealthStatus struct {
 // reads health identically.
 //
 // A parseable body yields a non-nil, Reachable HealthStatus with its reported
-// Status (a missing/odd status fails safe to "degraded"). An unparseable body
-// yields (nil, error).
+// Status (a missing/odd status fails safe to HealthDegraded). An unparseable
+// body yields a non-nil snapshot with Reachable == false plus an error.
 func ParseHealthStatus(body []byte) (*HealthStatus, error) {
 	var result map[string]interface{}
 	// Always use JSON for the health endpoint.
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("health check: unparseable response: %w", err)
+		return &HealthStatus{Reachable: false}, fmt.Errorf("health check: unparseable response: %w", err)
 	}
 
 	// Reachable. Default Status to degraded so a missing/odd status field fails
 	// safe (readiness withheld) rather than falsely reading as ok.
 	hs := &HealthStatus{Reachable: true, Status: HealthDegraded, Detail: result}
 	if s, ok := result["status"].(string); ok && s != "" {
-		hs.Status = s
+		hs.Status = HealthState(s)
 	}
 	// Integrity is reported two ways: the public response uses a top-level
 	// integrity_ok bool; the admin response nests it as integrity.healthy (and
@@ -1700,7 +1705,7 @@ func ParseHealthStatus(body []byte) (*HealthStatus, error) {
 func (c *Client) HealthStatus() (*HealthStatus, error) {
 	respBody, err := c.makeRequest("GET", "/api/health", nil)
 	if err != nil {
-		return nil, err
+		return &HealthStatus{Reachable: false}, err
 	}
 	return ParseHealthStatus(respBody)
 }

--- a/client.go
+++ b/client.go
@@ -1634,23 +1634,71 @@ func (c *Client) RestoreCollection(collection string) (int, error) {
 	return result.RecordsRestored, nil
 }
 
-// Health checks if the ekoDB server is healthy
-func (c *Client) Health() error {
+// HealthStatus describes the result of an ekoDB /api/health probe.
+//
+// It is degraded-tolerant: a reachable server that reports "degraded" is a
+// successful result (err == nil) with Status == "degraded", NOT an error. An
+// error is returned only when the server is unreachable (connection refused,
+// timeout, non-2xx, or an unparseable body).
+//
+// Consumers MUST base connection/liveness decisions on Reachable (err == nil)
+// and treat "degraded" as a warning — never as a fatal or reconnect trigger.
+// The ekoDB server intentionally returns HTTP 200 while degraded so that
+// liveness probes do not restart a degraded-but-recoverable instance.
+type HealthStatus struct {
+	Reachable   bool                   // a valid /api/health response came back
+	Status      string                 // "ok" | "degraded" (unknown/missing -> "degraded")
+	IntegrityOK bool                   // body.integrity_ok
+	Detail      map[string]interface{} // full parsed body (admin fields when present)
+}
+
+// ParseHealthStatus interprets a raw /api/health response body per the health
+// contract. It is the single source of truth for that interpretation, reused by
+// Client.HealthStatus and by non-client probes (e.g. a service that GETs
+// /api/health with its own HTTP client for circuit-breaking) so every consumer
+// reads health identically.
+//
+// A parseable body is Reachable with its reported Status (a missing/odd status
+// fails safe to "degraded"). An unparseable body returns an error and
+// Reachable=false.
+func ParseHealthStatus(body []byte) (*HealthStatus, error) {
+	var result map[string]interface{}
+	// Always use JSON for the health endpoint.
+	if err := json.Unmarshal(body, &result); err != nil {
+		return &HealthStatus{Reachable: false}, fmt.Errorf("health check: unparseable response: %w", err)
+	}
+
+	// Reachable. Default Status to "degraded" so a missing/odd status field
+	// fails safe (readiness withheld) rather than falsely reading as "ok".
+	hs := &HealthStatus{Reachable: true, Status: "degraded", Detail: result}
+	if s, ok := result["status"].(string); ok && s != "" {
+		hs.Status = s
+	}
+	if b, ok := result["integrity_ok"].(bool); ok {
+		hs.IntegrityOK = b
+	}
+	return hs, nil
+}
+
+// HealthStatus probes /api/health and returns structured, degraded-tolerant
+// state. See the HealthStatus type for the contract.
+func (c *Client) HealthStatus() (*HealthStatus, error) {
 	respBody, err := c.makeRequest("GET", "/api/health", nil)
 	if err != nil {
-		return err
+		return &HealthStatus{Reachable: false}, err
 	}
+	return ParseHealthStatus(respBody)
+}
 
-	var result map[string]interface{}
-	// Always use JSON for health endpoint
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return err
-	}
-
-	// Check if status is "ok"
-	if status, ok := result["status"].(string); ok && status == "ok" {
-		return nil
-	}
-
-	return fmt.Errorf("health check failed: unexpected response")
+// Health reports whether the ekoDB server is reachable.
+//
+// It returns nil whenever the server answers /api/health — including when the
+// server reports "degraded" — and returns an error only when the server is
+// unreachable. Use HealthStatus for the "ok" vs "degraded" distinction. This
+// is intentionally reachable-only: gating a connection on "status == ok"
+// conflates readiness with liveness and blocks startup against a
+// degraded-but-serving instance.
+func (c *Client) Health() error {
+	_, err := c.HealthStatus()
+	return err
 }

--- a/client.go
+++ b/client.go
@@ -1642,6 +1642,11 @@ type HealthState string
 const (
 	HealthOK       HealthState = "ok"
 	HealthDegraded HealthState = "degraded"
+	// HealthUnknown is the Status of a snapshot returned when the server is
+	// unreachable or its response is unparseable (always paired with a non-nil
+	// error), so the serialized snapshot carries a meaningful status rather than
+	// an empty string.
+	HealthUnknown HealthState = "unknown"
 )
 
 // HealthStatus is a snapshot of an ekoDB /api/health probe. It is safe to
@@ -1677,7 +1682,7 @@ func ParseHealthStatus(body []byte) (*HealthStatus, error) {
 	var result map[string]interface{}
 	// Always use JSON for the health endpoint.
 	if err := json.Unmarshal(body, &result); err != nil {
-		return &HealthStatus{Reachable: false}, fmt.Errorf("health check: unparseable response: %w", err)
+		return &HealthStatus{Reachable: false, Status: HealthUnknown}, fmt.Errorf("health check: unparseable response: %w", err)
 	}
 
 	// Reachable. Default Status to degraded so a missing/odd status field fails
@@ -1705,7 +1710,7 @@ func ParseHealthStatus(body []byte) (*HealthStatus, error) {
 func (c *Client) HealthStatus() (*HealthStatus, error) {
 	respBody, err := c.makeRequest("GET", "/api/health", nil)
 	if err != nil {
-		return &HealthStatus{Reachable: false}, err
+		return &HealthStatus{Reachable: false, Status: HealthUnknown}, err
 	}
 	return ParseHealthStatus(respBody)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -290,20 +290,29 @@ func TestHealthSuccess(t *testing.T) {
 	}
 }
 
+// Health() reports reachability, not readiness. A reachable server never errors,
+// even when it reports a non-ok status (use HealthStatus for the ok/degraded
+// distinction). Health() errors only when the server is unreachable.
 func TestHealthFailure(t *testing.T) {
 	handlers := map[string]http.HandlerFunc{
 		"GET /api/health": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]string{"status": "unhealthy"})
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "degraded"})
 		},
 	}
 	server := createTestServer(t, handlers)
-	defer server.Close()
 
 	client := createTestClient(t, server)
-	err := client.Health()
-	if err == nil {
-		t.Error("Expected Health() to fail for unhealthy status")
+
+	// Reachable but degraded -> tolerated, no error.
+	if err := client.Health(); err != nil {
+		t.Errorf("Health() must tolerate a reachable degraded server, got: %v", err)
+	}
+
+	// Unreachable -> error.
+	server.Close()
+	if err := client.Health(); err == nil {
+		t.Error("Expected Health() to fail when the server is unreachable")
 	}
 }
 

--- a/health_status_test.go
+++ b/health_status_test.go
@@ -3,6 +3,7 @@ package ekodb
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -182,5 +183,58 @@ func TestParseHealthStatus_AdminShapeDegraded(t *testing.T) {
 func TestHealthStatusConstants(t *testing.T) {
 	if HealthOK != "ok" || HealthDegraded != "degraded" {
 		t.Errorf("unexpected status constants: %q / %q", HealthOK, HealthDegraded)
+	}
+}
+
+// The snapshot is JSON-serializable with stable field names, so a consumer can
+// surface it directly (e.g. on a status page).
+func TestHealthStatus_JSONShape(t *testing.T) {
+	hs := &HealthStatus{Reachable: true, Status: HealthDegraded, IntegrityOK: false, Detail: map[string]interface{}{"x": 1}}
+	b, err := json.Marshal(hs)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	for _, k := range []string{"reachable", "status", "integrity_ok", "detail"} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing key %q in %s", k, b)
+		}
+	}
+	if m["status"] != "degraded" {
+		t.Errorf("status = %v, want degraded", m["status"])
+	}
+	if m["reachable"] != true {
+		t.Errorf("reachable = %v, want true", m["reachable"])
+	}
+	// detail is omitempty: absent on an empty snapshot
+	b2, _ := json.Marshal(&HealthStatus{Reachable: false, Status: HealthUnknown})
+	if strings.Contains(string(b2), "detail") {
+		t.Errorf("empty detail should be omitted, got %s", b2)
+	}
+}
+
+// An unreachable/unparseable snapshot reports Status HealthUnknown (not an empty
+// string) so the serialized DTO is coherent.
+func TestHealthStatus_UnreachableSnapshotIsUnknown(t *testing.T) {
+	client, closeFn := healthTestServer(t, map[string]interface{}{"status": "ok"})
+	closeFn() // unreachable
+
+	hs, err := client.HealthStatus()
+	if err == nil {
+		t.Fatalf("expected an error for an unreachable server")
+	}
+	if hs == nil || hs.Reachable || hs.Status != HealthUnknown {
+		t.Errorf("unreachable snapshot should be {Reachable:false, Status:HealthUnknown}, got %+v", hs)
+	}
+
+	hs2, err2 := ParseHealthStatus([]byte("not json"))
+	if err2 == nil {
+		t.Fatal("expected an error for an unparseable body")
+	}
+	if hs2 == nil || hs2.Status != HealthUnknown {
+		t.Errorf("unparseable snapshot should have Status HealthUnknown, got %+v", hs2)
 	}
 }

--- a/health_status_test.go
+++ b/health_status_test.go
@@ -74,8 +74,31 @@ func TestHealthStatus_UnreachableErrors(t *testing.T) {
 	if err == nil {
 		t.Fatalf("HealthStatus against a down server must error")
 	}
-	if hs != nil && hs.Reachable {
-		t.Errorf("expected Reachable=false when unreachable")
+	if hs != nil {
+		t.Errorf("expected nil HealthStatus on unreachable, got %+v", hs)
+	}
+}
+
+// A reachable server returning a non-2xx status is unreachable for the contract:
+// error, nil HealthStatus (guards the "non-2xx -> error" branch wavescd's
+// liveness gate relies on).
+func TestHealthStatus_Non2xxErrors(t *testing.T) {
+	handlers := map[string]http.HandlerFunc{
+		"GET /api/health": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"status":"degraded"}`))
+		},
+	}
+	server := createTestServer(t, handlers)
+	defer server.Close()
+	client := createTestClient(t, server)
+
+	hs, err := client.HealthStatus()
+	if err == nil {
+		t.Fatalf("a 503 from /api/health must error (non-2xx is not reachable)")
+	}
+	if hs != nil {
+		t.Errorf("expected nil HealthStatus on a non-2xx response, got %+v", hs)
 	}
 }
 
@@ -120,7 +143,7 @@ func TestParseHealthStatus_GarbageIsUnreachable(t *testing.T) {
 	if err == nil {
 		t.Fatal("unparseable body must error")
 	}
-	if hs.Reachable {
-		t.Error("unparseable body must not be Reachable")
+	if hs != nil {
+		t.Errorf("expected nil HealthStatus on an unparseable body, got %+v", hs)
 	}
 }

--- a/health_status_test.go
+++ b/health_status_test.go
@@ -147,3 +147,40 @@ func TestParseHealthStatus_GarbageIsUnreachable(t *testing.T) {
 		t.Errorf("expected nil HealthStatus on an unparseable body, got %+v", hs)
 	}
 }
+
+// The admin /api/health response nests integrity as integrity.healthy (there is
+// NO top-level integrity_ok); the clients authenticate as admin, so IntegrityOK
+// must read that nested shape. A healthy admin body is the discriminating case:
+// the old code read the absent top-level key and defaulted IntegrityOK to false.
+func TestParseHealthStatus_AdminShapeHealthy(t *testing.T) {
+	hs, err := ParseHealthStatus([]byte(`{"status":"ok","integrity":{"healthy":true,"manifest_load_failed":[]}}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hs.Status != "ok" {
+		t.Errorf("expected Status=ok, got %q", hs.Status)
+	}
+	if !hs.IntegrityOK {
+		t.Errorf("admin shape: IntegrityOK must come from integrity.healthy (got false)")
+	}
+}
+
+func TestParseHealthStatus_AdminShapeDegraded(t *testing.T) {
+	hs, err := ParseHealthStatus([]byte(`{"status":"degraded","integrity":{"healthy":false,"manifest_load_failed":["deployment_operations"]}}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hs.Status != "degraded" {
+		t.Errorf("expected Status=degraded, got %q", hs.Status)
+	}
+	if hs.IntegrityOK {
+		t.Errorf("admin shape: IntegrityOK must be false when integrity.healthy is false")
+	}
+}
+
+// Constants exist for the Status values so consumers compare against a symbol.
+func TestHealthStatusConstants(t *testing.T) {
+	if HealthOK != "ok" || HealthDegraded != "degraded" {
+		t.Errorf("unexpected status constants: %q / %q", HealthOK, HealthDegraded)
+	}
+}

--- a/health_status_test.go
+++ b/health_status_test.go
@@ -74,8 +74,8 @@ func TestHealthStatus_UnreachableErrors(t *testing.T) {
 	if err == nil {
 		t.Fatalf("HealthStatus against a down server must error")
 	}
-	if hs != nil {
-		t.Errorf("expected nil HealthStatus on unreachable, got %+v", hs)
+	if hs == nil || hs.Reachable {
+		t.Errorf("expected a non-nil, unreachable snapshot, got %+v", hs)
 	}
 }
 
@@ -97,8 +97,8 @@ func TestHealthStatus_Non2xxErrors(t *testing.T) {
 	if err == nil {
 		t.Fatalf("a 503 from /api/health must error (non-2xx is not reachable)")
 	}
-	if hs != nil {
-		t.Errorf("expected nil HealthStatus on a non-2xx response, got %+v", hs)
+	if hs == nil || hs.Reachable {
+		t.Errorf("expected a non-nil, unreachable snapshot on a non-2xx response, got %+v", hs)
 	}
 }
 
@@ -143,8 +143,8 @@ func TestParseHealthStatus_GarbageIsUnreachable(t *testing.T) {
 	if err == nil {
 		t.Fatal("unparseable body must error")
 	}
-	if hs != nil {
-		t.Errorf("expected nil HealthStatus on an unparseable body, got %+v", hs)
+	if hs == nil || hs.Reachable {
+		t.Errorf("expected a non-nil, unreachable snapshot on an unparseable body, got %+v", hs)
 	}
 }
 

--- a/health_status_test.go
+++ b/health_status_test.go
@@ -186,10 +186,16 @@ func TestHealthStatusConstants(t *testing.T) {
 	}
 }
 
-// The snapshot is JSON-serializable with stable field names, so a consumer can
-// surface it directly (e.g. on a status page).
+// The snapshot serializes to a safe summary (reachable/status/integrity_ok) that
+// a consumer can surface directly. Detail carries the full, possibly sensitive
+// admin body and MUST NOT be serialized.
 func TestHealthStatus_JSONShape(t *testing.T) {
-	hs := &HealthStatus{Reachable: true, Status: HealthDegraded, IntegrityOK: false, Detail: map[string]interface{}{"x": 1}}
+	hs := &HealthStatus{
+		Reachable:   true,
+		Status:      HealthDegraded,
+		IntegrityOK: false,
+		Detail:      map[string]interface{}{"manifest_load_failed": []string{"secret_collection"}},
+	}
 	b, err := json.Marshal(hs)
 	if err != nil {
 		t.Fatalf("marshal failed: %v", err)
@@ -198,7 +204,7 @@ func TestHealthStatus_JSONShape(t *testing.T) {
 	if err := json.Unmarshal(b, &m); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
-	for _, k := range []string{"reachable", "status", "integrity_ok", "detail"} {
+	for _, k := range []string{"reachable", "status", "integrity_ok"} {
 		if _, ok := m[k]; !ok {
 			t.Errorf("missing key %q in %s", k, b)
 		}
@@ -209,10 +215,13 @@ func TestHealthStatus_JSONShape(t *testing.T) {
 	if m["reachable"] != true {
 		t.Errorf("reachable = %v, want true", m["reachable"])
 	}
-	// detail is omitempty: absent on an empty snapshot
-	b2, _ := json.Marshal(&HealthStatus{Reachable: false, Status: HealthUnknown})
-	if strings.Contains(string(b2), "detail") {
-		t.Errorf("empty detail should be omitted, got %s", b2)
+	// Detail must not be serialized (even when populated), so the internal admin
+	// body is never leaked when the snapshot is surfaced.
+	if _, ok := m["detail"]; ok {
+		t.Errorf("detail must not be serialized, got %s", b)
+	}
+	if strings.Contains(string(b), "secret_collection") {
+		t.Errorf("internal detail leaked into the serialized snapshot: %s", b)
 	}
 }
 

--- a/health_status_test.go
+++ b/health_status_test.go
@@ -1,0 +1,126 @@
+package ekodb
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// healthTestServer stands up a mock ekoDB whose /api/health returns the given body.
+func healthTestServer(t *testing.T, body map[string]interface{}) (*Client, func()) {
+	t.Helper()
+	handlers := map[string]http.HandlerFunc{
+		"GET /api/health": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(body)
+		},
+	}
+	server := createTestServer(t, handlers)
+	client := createTestClient(t, server)
+	return client, server.Close
+}
+
+// A healthy server: status "ok" -> reachable, ok, no error.
+func TestHealthStatus_Ok(t *testing.T) {
+	client, closeFn := healthTestServer(t, map[string]interface{}{
+		"status": "ok", "integrity_ok": true,
+	})
+	defer closeFn()
+
+	hs, err := client.HealthStatus()
+	if err != nil {
+		t.Fatalf("HealthStatus on a healthy server should not error, got: %v", err)
+	}
+	if !hs.Reachable {
+		t.Errorf("expected Reachable=true")
+	}
+	if hs.Status != "ok" {
+		t.Errorf("expected Status=ok, got %q", hs.Status)
+	}
+	if !hs.IntegrityOK {
+		t.Errorf("expected IntegrityOK=true")
+	}
+}
+
+// The crux: a degraded (HTTP 200) server is REACHABLE, not an error.
+func TestHealthStatus_DegradedIsNotAnError(t *testing.T) {
+	client, closeFn := healthTestServer(t, map[string]interface{}{
+		"status": "degraded", "integrity_ok": false,
+	})
+	defer closeFn()
+
+	hs, err := client.HealthStatus()
+	if err != nil {
+		t.Fatalf("degraded is reachable-but-unhealthy, must NOT error, got: %v", err)
+	}
+	if !hs.Reachable {
+		t.Errorf("expected Reachable=true for a 200 degraded response")
+	}
+	if hs.Status != "degraded" {
+		t.Errorf("expected Status=degraded, got %q", hs.Status)
+	}
+	if hs.IntegrityOK {
+		t.Errorf("expected IntegrityOK=false")
+	}
+}
+
+// An unreachable server -> error, Reachable=false.
+func TestHealthStatus_UnreachableErrors(t *testing.T) {
+	client, closeFn := healthTestServer(t, map[string]interface{}{"status": "ok"})
+	closeFn() // kill the server before probing
+
+	hs, err := client.HealthStatus()
+	if err == nil {
+		t.Fatalf("HealthStatus against a down server must error")
+	}
+	if hs != nil && hs.Reachable {
+		t.Errorf("expected Reachable=false when unreachable")
+	}
+}
+
+// Health() is now reachable-only: degraded must NOT error (regression guard for the
+// currentcs boot bug where degraded made Health() fail and blocked startup).
+func TestHealth_ReachableOnlyToleratesDegraded(t *testing.T) {
+	client, closeFn := healthTestServer(t, map[string]interface{}{
+		"status": "degraded", "integrity_ok": false,
+	})
+	defer closeFn()
+
+	if err := client.Health(); err != nil {
+		t.Fatalf("Health() must tolerate degraded (reachable-only), got: %v", err)
+	}
+}
+
+// ParseHealthStatus is the shared contract parser reused by non-client probes
+// (e.g. wavescd's circuit-breaker health check) so every consumer interprets
+// /api/health identically.
+func TestParseHealthStatus_DegradedIsReachable(t *testing.T) {
+	hs, err := ParseHealthStatus([]byte(`{"status":"degraded","integrity_ok":false}`))
+	if err != nil {
+		t.Fatalf("degraded body must parse without error, got: %v", err)
+	}
+	if !hs.Reachable || hs.Status != "degraded" || hs.IntegrityOK {
+		t.Errorf("got %+v", hs)
+	}
+}
+
+func TestParseHealthStatus_MissingStatusFailsSafeToDegraded(t *testing.T) {
+	hs, err := ParseHealthStatus([]byte(`{"integrity_ok":true}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hs.Status != "degraded" {
+		t.Errorf("a missing status must fail safe to degraded, got %q", hs.Status)
+	}
+}
+
+func TestParseHealthStatus_GarbageIsUnreachable(t *testing.T) {
+	hs, err := ParseHealthStatus([]byte(`not json`))
+	if err == nil {
+		t.Fatal("unparseable body must error")
+	}
+	if hs.Reachable {
+		t.Error("unparseable body must not be Reachable")
+	}
+}


### PR DESCRIPTION
## What & why

Refs #58.

The ekoDB server returns **HTTP 200 even when its health is `degraded`** (by design, so a degraded-but-serving instance isn't restarted by a liveness probe), and reports the real state in the body:

```json
{ "status": "degraded", "integrity_ok": false }
```

`Client.Health()` treated any non-`"ok"` body as an error, so callers using `Health()` as a liveness/connection gate treated a degraded-but-serving ekoDB as down, conflating readiness with liveness. There was also no way to read the `ok` vs `degraded` distinction from the client. This PR adds a structured, degraded-tolerant health API and makes `Health()` reachable-only.

### Changes

- **Add `HealthStatus` type**: `{ Reachable, Status ("ok"|"degraded"), IntegrityOK, Detail }`.
- **Add `Client.HealthStatus() (*HealthStatus, error)`**, degraded-tolerant. It errors only when the server is unreachable (connection refused, timeout, non-2xx, unparseable body). A `degraded` HTTP-200 response is a successful result with `Status == "degraded"`.
- **Add `ParseHealthStatus(body []byte)`**, the single shared interpreter of an `/api/health` body, reusable by non-client probes so every consumer reads health identically. A missing/odd `status` fails safe to `"degraded"`.
- **Behavior change: `Client.Health()` is now reachable-only.** It returns nil whenever the server responds (including `degraded`) and errors only when unreachable. Use `HealthStatus()` for the `ok` vs `degraded` distinction. Documented in the CHANGELOG under `[Unreleased]`.

## Reviewer checklist (before merge)

- [x] **Data contract traced end to end:** `/api/health` body, then `ParseHealthStatus`, then `HealthStatus()`/`Health()`; the single parser is the one source of truth, reused by `HealthStatus()`.
- [x] Every reshaping layer has a test asserting the whole contract: `HealthStatus` fields asserted for ok / degraded / unreachable / missing-status.
- [x] **Real path verified:** unit tests drive an `httptest` server through the token exchange and `/api/health` for each case; suite green.
- [x] No dead, speculative, or unwired code; no "known gaps".
- [x] Tests cover happy, error, and boundary paths (ok / degraded / unreachable / missing-status; `Health()` tolerates degraded; unreachable still errors).
- [x] Docs updated; CHANGELOG under `[Unreleased]` (dated and version bumped at release).
- [x] Behavior change (`Health()` reachable-only) recorded as a "Changed" entry.

## Verification evidence

```
go test -run 'Health|ParseHealthStatus' ./...
ok  	github.com/ekoDB/ekodb-client-go
```

Cases covered: `status:"ok"` gives no error and `ok`; `status:"degraded"` (HTTP 200) gives no error and `Status=="degraded"`; server down gives an error and `Reachable=false`; missing `status` fails safe to `"degraded"`; `Health()` returns nil on degraded. The prior test that pinned `Health()` erroring on a non-ok status was updated to the reachable-only contract.
