### PR TITLE
chore: use neutral wording in health status test comments

### DIFF
--- a/health_status_test.go
+++ b/health_status_test.go
@@ -81,8 +81,8 @@ func TestHealthStatus_UnreachableErrors(t *testing.T) {
 }
 
 // A reachable server returning a non-2xx status is unreachable for the contract:
-// error, nil HealthStatus (guards the "non-2xx -> error" branch wavescd's
-// liveness gate relies on).
+// error, nil HealthStatus (guards the "non-2xx -> error" branch that downstream
+// liveness gates rely on).
 func TestHealthStatus_Non2xxErrors(t *testing.T) {
 	handlers := map[string]http.HandlerFunc{
 		"GET /api/health": func(w http.ResponseWriter, _ *http.Request) {
@@ -103,8 +103,8 @@ func TestHealthStatus_Non2xxErrors(t *testing.T) {
 	}
 }
 
-// Health() is now reachable-only: degraded must NOT error (regression guard for the
-// currentcs boot bug where degraded made Health() fail and blocked startup).
+// Health() is now reachable-only: degraded must NOT error (regression guard: treating
+// degraded as a hard failure previously blocked consumer startup).
 func TestHealth_ReachableOnlyToleratesDegraded(t *testing.T) {
 	client, closeFn := healthTestServer(t, map[string]interface{}{
 		"status": "degraded", "integrity_ok": false,
@@ -117,8 +117,8 @@ func TestHealth_ReachableOnlyToleratesDegraded(t *testing.T) {
 }
 
 // ParseHealthStatus is the shared contract parser reused by non-client probes
-// (e.g. wavescd's circuit-breaker health check) so every consumer interprets
-// /api/health identically.
+// (e.g. circuit-breaker health checks in downstream services) so every consumer
+// interprets /api/health identically.
 func TestParseHealthStatus_DegradedIsReachable(t *testing.T) {
 	hs, err := ParseHealthStatus([]byte(`{"status":"degraded","integrity_ok":false}`))
 	if err != nil {


### PR DESCRIPTION
## Problem

Three comments in `health_status_test.go` explained why the regression guards exist by naming specific internal services and describing an internal startup failure. This repository is public, so that context does not belong in it.

## Change

Reworded the three comments in neutral terms. The rationale each comment carries is preserved, since that is the useful part; only the internal identifiers and the incident detail are removed.

- `:83-85` liveness-gate rationale, now phrased as downstream liveness gates.
- `:106-107` degraded-tolerance regression guard, now phrased as consumer startup.
- `:119-121` shared-parser rationale, now phrased as downstream circuit-breaker probes.

Comments only. No behavior change, no exported API change, no test logic touched.

## Verification

- `make test` green, 430 tests.
- `go build ./...` clean.
- `golangci-lint` 0 issues, `go vet` clean, `gofmt` clean (all via the pre-commit hook).
- Repo grep confirms no internal service identifiers remain.

## Note

Rewording fixes the current tree and every future reader. The original strings remain in git history, which would require a force-push on a public repo to remove and is not proposed here.
