### PR TITLE
chore: use neutral wording in health status test comments

### DIFF
--- a/health_status_test.go
+++ b/health_status_test.go
@@ -81,8 +81,8 @@ func TestHealthStatus_UnreachableErrors(t *testing.T) {
 }
 
 // A reachable server returning a non-2xx status is unreachable for the contract:
-// error, nil HealthStatus (guards the "non-2xx -> error" branch wavescd's
-// liveness gate relies on).
+// error, nil HealthStatus (guards the "non-2xx -> error" branch that downstream
+// liveness gates rely on).
 func TestHealthStatus_Non2xxErrors(t *testing.T) {
 	handlers := map[string]http.HandlerFunc{
 		"GET /api/health": func(w http.ResponseWriter, _ *http.Request) {
@@ -103,8 +103,8 @@ func TestHealthStatus_Non2xxErrors(t *testing.T) {
 	}
 }
 
-// Health() is now reachable-only: degraded must NOT error (regression guard for the
-// currentcs boot bug where degraded made Health() fail and blocked startup).
+// Health() is now reachable-only: degraded must NOT error (regression guard: treating
+// degraded as a hard failure previously blocked consumer startup).
 func TestHealth_ReachableOnlyToleratesDegraded(t *testing.T) {
 	client, closeFn := healthTestServer(t, map[string]interface{}{
 		"status": "degraded", "integrity_ok": false,
@@ -117,8 +117,8 @@ func TestHealth_ReachableOnlyToleratesDegraded(t *testing.T) {
 }
 
 // ParseHealthStatus is the shared contract parser reused by non-client probes
-// (e.g. wavescd's circuit-breaker health check) so every consumer interprets
-// /api/health identically.
+// (e.g. circuit-breaker health checks in downstream services) so every consumer
+// interprets /api/health identically.
 func TestParseHealthStatus_DegradedIsReachable(t *testing.T) {
 	hs, err := ParseHealthStatus([]byte(`{"status":"degraded","integrity_ok":false}`))
 	if err != nil {


### PR DESCRIPTION
The comments explaining why these regression guards exist named specific internal services and described an internal startup failure. This repo is public, so the rationale is kept but reworded in neutral terms.

No behavior change; comments only.

## What & why

<One-line summary. Ticket refs: `Refs #…` (the maintainer closes tickets after
review).>

## Reviewer checklist (before merge)

- [ ] **Data contract traced end to end:** every field/value flows intact
      through every layer that transforms it (e.g. handler, serializer,
      transport, client mapping, UI); no layer silently drops or renames it.
- [ ] Every layer that reshapes a payload has a test asserting the **whole**
      contract (all fields), not a subset. Prefer one shared builder over
      duplicated hand-built objects so they cannot drift.
- [ ] **Real path verified, not just unit tests:** drove the running code,
      captured the real payload at the boundary, confirmed the observable
      output. Green units plus approved reviews are not proof it works.
- [ ] No dead, speculative, or unwired code; no "known gaps".
- [ ] Tests cover happy, error, and boundary paths.
- [ ] Docs updated; CHANGELOG under `[Unreleased]` (committed at release).
- [ ] Cross-surface parity where relevant (server and all clients, CLI and GUI,
      code and docs).

## Verification evidence

<How the real path was verified: payloads, screenshots, or test output.>
