### PR TITLE
feat(chat): ChatModels carries Gemini and Providers; stream errors carry the classification (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to
   lines up to 1 MiB (the scanner's default 64 KiB limit truncated a large token
   or tool payload silently, as `SubscribeSSE` already avoided) and reports a
   stream the scanner could not read to its end as an `error` event
-  (`stream read failed: …`) instead of a clean close.
+  (`stream read failed: …`) instead of a clean close. The classification travels as one unit: without an `error_kind` an event carries no `Provider` / `ProviderStatus` / `RetryAfterSecs`, on either route.
 
 ## [0.25.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@ and this project adheres to
   the event's other optional strings — plus the provider's own `ProviderStatus`
   and `RetryAfterSecs` (pointers, since 0 is a value there), on both SSE and
   WebSocket streams, and `IsProviderFailure()` reports whether they are there. A
-  transport failure or a plain server error stays a bare `Error`.
+  transport failure or a plain server error stays a bare `Error`. The SSE loop
+  recognises an error frame by its `event: error` name as well as by an `error`
+  key, and on both routes a payload that says `message` instead of `error` is
+  still the error rather than a frame to skip.
 
 ## [0.25.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,11 @@ and this project adheres to
   transport failure or a plain server error stays a bare `Error`. The SSE loop
   recognises an error frame by its `event: error` name as well as by an `error`
   key, and on both routes a payload that says `message` instead of `error` is
-  still the error rather than a frame to skip.
+  still the error rather than a frame to skip. `ChatMessageStream` reads SSE
+  lines up to 1 MiB (the scanner's default 64 KiB limit truncated a large token
+  or tool payload silently, as `SubscribeSSE` already avoided) and reports a
+  stream the scanner could not read to its end as an `error` event
+  (`stream read failed: …`) instead of a clean close.
 
 ## [0.25.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.26.0] - 2026-09-04
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`ChatModels` carries `Gemini` and a per-provider `Providers` status map
+  (#61).** `GET /api/chat_models` now says _why_ each provider's list looks the
+  way it does, so a rejected key is distinguishable from a missing one — both
+  were an empty list before. `ChatModels.Gemini []string` and
+  `ChatModels.Providers map[string]ChatProviderStatus`, where
+  `ChatProviderStatus { Status ChatProviderState; Verified bool; HTTPStatus, Message, ModelCount (pointers, present when the provider answered) }`
+  and `IsUsable()` reports `Status == ChatProviderOK`. `ChatProviderState` is a
+  string type with constants for the nine documented states; an unknown state
+  decodes as its raw string, so a newer server cannot break the client. Both
+  fields are `omitempty` and nil from a server that predates them. Pairs with
+  the server-side change, tracked internally.
+- **`ChatStreamEvent` carries the provider-failure classification.** When a chat
+  stream fails because of the LLM provider, the server classifies the failure;
+  the `error` event now carries `ErrorKind` (`provider_auth_failed`,
+  `provider_permission_denied`, `provider_billing`, `provider_rate_limited`,
+  `provider_unavailable`, `provider_unreachable`, `provider_not_configured`,
+  `provider_request_error`), `Provider`, the provider's own `ProviderStatus` and
+  `RetryAfterSecs` (pointers, present when sent), on both SSE and WebSocket
+  streams, and `IsProviderFailure()` reports whether they are there. A transport
+  failure or a plain server error stays a bare `Error`.
+
 ## [0.25.0] - 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ and this project adheres to
   the `error` event now carries `ErrorKind` (`provider_auth_failed`,
   `provider_permission_denied`, `provider_billing`, `provider_rate_limited`,
   `provider_unavailable`, `provider_unreachable`, `provider_not_configured`,
-  `provider_request_error`), `Provider`, the provider's own `ProviderStatus` and
-  `RetryAfterSecs` (pointers, present when sent), on both SSE and WebSocket
-  streams, and `IsProviderFailure()` reports whether they are there. A transport
-  failure or a plain server error stays a bare `Error`.
+  `provider_request_error`) and `Provider` — strings, empty when not sent, like
+  the event's other optional strings — plus the provider's own `ProviderStatus`
+  and `RetryAfterSecs` (pointers, since 0 is a value there), on both SSE and
+  WebSocket streams, and `IsProviderFailure()` reports whether they are there. A
+  transport failure or a plain server error stays a bare `Error`.
 
 ## [0.25.0] - 2026-07-14
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,10 @@ within the transaction.
 ### Chat Models
 
 - `GetChatModels() (*ChatModels, error)` - Get all available chat models by
-  provider
+  provider (`OpenAI`, `Anthropic`, `Perplexity`, `Gemini`), plus `Providers`: a
+  per-provider `ChatProviderStatus` (`ok`, `not_configured`, `auth_failed`,
+  `permission_denied`, `billing`, `rate_limited`, `unavailable`, `unreachable`,
+  `request_error`) so a rejected key is distinguishable from a missing one
 - `GetChatModel(provider string) ([]string, error)` - Get models for a specific
   provider
 

--- a/chat.go
+++ b/chat.go
@@ -225,11 +225,65 @@ type CompactChatResponse struct {
 	AlreadyCompact   bool    `json:"already_compact"`
 }
 
-// ChatModels contains available models for each provider
+// ChatModels contains available models for each provider, and why each list
+// looks the way it does.
 type ChatModels struct {
 	OpenAI     []string `json:"openai"`
 	Anthropic  []string `json:"anthropic"`
 	Perplexity []string `json:"perplexity"`
+	// Gemini is empty from a server that predates the field.
+	Gemini []string `json:"gemini,omitempty"`
+	// Providers is keyed by provider name ("openai", "anthropic", "perplexity",
+	// "gemini"). A rejected key reports auth_failed where a missing one reports
+	// not_configured, so an empty list is never ambiguous. Nil from a server
+	// that predates the map.
+	Providers map[string]ChatProviderStatus `json:"providers,omitempty"`
+}
+
+// ChatProviderState is a provider's state on GET /api/chat_models. A status
+// this client version does not know decodes as its raw string, so a newer
+// server cannot break the client.
+type ChatProviderState string
+
+const (
+	// ChatProviderOK: the provider listed its models with the configured key.
+	ChatProviderOK ChatProviderState = "ok"
+	// ChatProviderNotConfigured: no key (for an OpenAI-compatible endpoint: no key and no URL).
+	ChatProviderNotConfigured ChatProviderState = "not_configured"
+	// ChatProviderAuthFailed: the provider rejected the key (401).
+	ChatProviderAuthFailed ChatProviderState = "auth_failed"
+	// ChatProviderPermissionDenied: the key may not use this resource or region (403).
+	ChatProviderPermissionDenied ChatProviderState = "permission_denied"
+	// ChatProviderBilling: the account cannot pay (402, or a quota / spend-limit code).
+	ChatProviderBilling ChatProviderState = "billing"
+	// ChatProviderRateLimited: the provider is rate limiting the server (429).
+	ChatProviderRateLimited ChatProviderState = "rate_limited"
+	// ChatProviderUnavailable: the provider answered 5xx or an unusable body.
+	ChatProviderUnavailable ChatProviderState = "unavailable"
+	// ChatProviderUnreachable: nothing answered — DNS, connect, TLS, or a timeout.
+	ChatProviderUnreachable ChatProviderState = "unreachable"
+	// ChatProviderRequestError: the provider refused the request itself (any other 4xx).
+	ChatProviderRequestError ChatProviderState = "request_error"
+)
+
+// ChatProviderStatus is one provider's row in ChatModels.Providers.
+type ChatProviderStatus struct {
+	Status ChatProviderState `json:"status"`
+	// Verified is true when the status is the provider's own answer about the
+	// configured key. A 5xx, a refused connection, or a missing key says
+	// nothing about it.
+	Verified bool `json:"verified"`
+	// HTTPStatus is the provider's own status, when it answered.
+	HTTPStatus *int `json:"http_status,omitempty"`
+	// Message is the provider's own message, when it answered.
+	Message *string `json:"message,omitempty"`
+	// ModelCount is how many models were listed, when the status is ok.
+	ModelCount *int `json:"model_count,omitempty"`
+}
+
+// IsUsable reports whether the provider listed its models with the configured key.
+func (s ChatProviderStatus) IsUsable() bool {
+	return s.Status == ChatProviderOK
 }
 
 // EmbedRequest is the request body for POST /api/embed
@@ -941,9 +995,9 @@ func (c *Client) ChatMessageStream(ctx context.Context, sessionID string, reques
 				return
 			}
 
-			// Error event
-			if errMsg, ok := eventData["error"].(string); ok {
-				send(ChatStreamEvent{Type: "error", Error: errMsg})
+			// Error event, with the provider-failure classification when present
+			if _, ok := eventData["error"].(string); ok {
+				send(chatStreamErrorEvent(eventData))
 				return
 			}
 		}

--- a/chat.go
+++ b/chat.go
@@ -948,6 +948,10 @@ func (c *Client) ChatMessageStream(ctx context.Context, sessionID string, reques
 		}
 
 		scanner := bufio.NewScanner(resp.Body)
+		// A single data line can carry a large token or tool payload; the
+		// scanner's default 64 KiB line limit would truncate the stream
+		// silently. Same sizing as SubscribeSSE.
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		// The `event:` name applies to the data lines that follow it, until
 		// the blank line that ends the frame.
 		eventName := ""
@@ -1013,6 +1017,12 @@ func (c *Client) ChatMessageStream(ctx context.Context, sessionID string, reques
 				send(chatStreamErrorEvent(eventData))
 				return
 			}
+		}
+		// A stream the scanner could not read to its end (a broken
+		// connection, a line past the limit above) is a failure the consumer
+		// can distinguish from a clean end, never a silent close.
+		if err := scanner.Err(); err != nil {
+			send(ChatStreamEvent{Type: "error", Error: "stream read failed: " + err.Error()})
 		}
 	}()
 

--- a/chat.go
+++ b/chat.go
@@ -231,7 +231,7 @@ type ChatModels struct {
 	OpenAI     []string `json:"openai"`
 	Anthropic  []string `json:"anthropic"`
 	Perplexity []string `json:"perplexity"`
-	// Gemini is empty from a server that predates the field.
+	// Gemini is nil (len 0) from a server that predates the field.
 	Gemini []string `json:"gemini,omitempty"`
 	// Providers is keyed by provider name ("openai", "anthropic", "perplexity",
 	// "gemini"). A rejected key reports auth_failed where a missing one reports
@@ -948,8 +948,19 @@ func (c *Client) ChatMessageStream(ctx context.Context, sessionID string, reques
 		}
 
 		scanner := bufio.NewScanner(resp.Body)
+		// The `event:` name applies to the data lines that follow it, until
+		// the blank line that ends the frame.
+		eventName := ""
 		for scanner.Scan() {
 			line := scanner.Text()
+			if strings.HasPrefix(line, "event:") {
+				eventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+				continue
+			}
+			if strings.TrimSpace(line) == "" {
+				eventName = ""
+				continue
+			}
 			if !strings.HasPrefix(line, "data:") {
 				continue
 			}
@@ -995,8 +1006,10 @@ func (c *Client) ChatMessageStream(ctx context.Context, sessionID string, reques
 				return
 			}
 
-			// Error event, with the provider-failure classification when present
-			if _, ok := eventData["error"].(string); ok {
+			// Error event — one the server names `error`, or whose payload
+			// carries an `error` — with the provider-failure classification
+			// when present.
+			if _, ok := eventData["error"].(string); ok || eventName == "error" {
 				send(chatStreamErrorEvent(eventData))
 				return
 			}

--- a/chat_test.go
+++ b/chat_test.go
@@ -266,6 +266,38 @@ func TestChatMessageStreamError(t *testing.T) {
 	}
 }
 
+// The classification travels as one unit: without `error_kind` there is no
+// provider failure, so `Provider` / `ProviderStatus` / `RetryAfterSecs` stay
+// empty even if the frame happened to carry them.
+func TestChatMessageStreamErrorWithoutKindCarriesNoClassification(t *testing.T) {
+	server := createTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/chat/session_1/messages/stream": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, _ := w.(http.Flusher)
+			fmt.Fprintf(w, "data: {\"error\":\"Model unavailable\",\"provider\":\"openai\",\"provider_status\":503,\"retry_after_secs\":5}\n\n")
+			flusher.Flush()
+		},
+	})
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	ch, err := client.ChatMessageStream(context.Background(), "session_1", ChatMessageRequest{Message: "Hi"})
+	if err != nil {
+		t.Fatalf("ChatMessageStream failed: %v", err)
+	}
+	var events []ChatStreamEvent
+	for event := range ch {
+		events = append(events, event)
+	}
+	if len(events) != 1 || events[0].Type != "error" || events[0].Error != "Model unavailable" {
+		t.Fatalf("expected one plain error event, got %+v", events)
+	}
+	ev := events[0]
+	if ev.ErrorKind != "" || ev.Provider != "" || ev.ProviderStatus != nil || ev.RetryAfterSecs != nil || ev.IsProviderFailure() {
+		t.Fatalf("a frame without error_kind must carry no classification: %+v", ev)
+	}
+}
+
 // A single SSE data line can carry a large token or tool payload; the
 // scanner's default 64 KiB line limit must not truncate the stream silently.
 func TestChatMessageStreamCarriesALongDataLine(t *testing.T) {

--- a/chat_test.go
+++ b/chat_test.go
@@ -266,6 +266,67 @@ func TestChatMessageStreamError(t *testing.T) {
 	}
 }
 
+// A single SSE data line can carry a large token or tool payload; the
+// scanner's default 64 KiB line limit must not truncate the stream silently.
+func TestChatMessageStreamCarriesALongDataLine(t *testing.T) {
+	long := strings.Repeat("x", 200*1024)
+	server := createTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/chat/session_1/messages/stream": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, _ := w.(http.Flusher)
+			fmt.Fprintf(w, "data: {\"token\":\"%s\"}\n\n", long)
+			fmt.Fprintf(w, "data: {\"content\":\"done\",\"message_id\":\"m1\"}\n\n")
+			flusher.Flush()
+		},
+	})
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	ch, err := client.ChatMessageStream(context.Background(), "session_1", ChatMessageRequest{Message: "Hi"})
+	if err != nil {
+		t.Fatalf("ChatMessageStream failed: %v", err)
+	}
+	var events []ChatStreamEvent
+	for event := range ch {
+		events = append(events, event)
+	}
+	if len(events) != 2 || events[0].Type != "chunk" || len(events[0].Content) != len(long) || events[1].Type != "end" {
+		types := make([]string, 0, len(events))
+		for _, e := range events {
+			types = append(types, e.Type)
+		}
+		t.Fatalf("expected a %d-byte chunk then end, got %v", len(long), types)
+	}
+}
+
+// A stream the scanner cannot read to the end (here: a line past the 1 MiB
+// limit) is reported as an error event, never as a clean end.
+func TestChatMessageStreamReportsAScannerFailure(t *testing.T) {
+	huge := strings.Repeat("x", 2*1024*1024)
+	server := createTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/chat/session_1/messages/stream": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, _ := w.(http.Flusher)
+			fmt.Fprintf(w, "data: {\"token\":\"%s\"}\n\n", huge)
+			flusher.Flush()
+		},
+	})
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	ch, err := client.ChatMessageStream(context.Background(), "session_1", ChatMessageRequest{Message: "Hi"})
+	if err != nil {
+		t.Fatalf("ChatMessageStream failed: %v", err)
+	}
+	var events []ChatStreamEvent
+	for event := range ch {
+		events = append(events, event)
+	}
+	if len(events) != 1 || events[0].Type != "error" || !strings.Contains(events[0].Error, "token too long") || events[0].IsProviderFailure() {
+		t.Fatalf("expected one read-failure error event, got %+v", events)
+	}
+}
+
 // A frame the server names `error` is an error whatever its payload calls
 // the message, so a `message`-only payload is an error event rather than a
 // frame to skip.

--- a/chat_test.go
+++ b/chat_test.go
@@ -256,10 +256,63 @@ func TestChatMessageStreamError(t *testing.T) {
 			if event.Error != "Model unavailable" {
 				t.Errorf("Expected error 'Model unavailable', got '%s'", event.Error)
 			}
+			if event.ErrorKind != "" || event.Provider != "" || event.ProviderStatus != nil || event.IsProviderFailure() {
+				t.Errorf("a plain error must carry no classification: %+v", event)
+			}
 		}
 	}
 	if !gotError {
 		t.Fatal("Expected error event")
+	}
+}
+
+// The deployment classifies a provider failure (error_kind, provider,
+// provider_status, retry_after_secs); the event carries every field so a
+// consumer can act on it without string-matching. A plain error stays bare.
+func TestChatMessageStreamProviderFailure(t *testing.T) {
+	server := createTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/chat/session_1/messages/stream": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, _ := w.(http.Flusher)
+			fmt.Fprintf(w, "data:{\"error\":\"OpenAI API error 429 Too Many Requests\",\"error_kind\":\"provider_rate_limited\",\"provider\":\"openai\",\"provider_status\":429,\"retry_after_secs\":7}\n\n")
+			flusher.Flush()
+		},
+	})
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	ch, err := client.ChatMessageStream(context.Background(), "session_1", ChatMessageRequest{Message: "Hi"})
+	if err != nil {
+		t.Fatalf("ChatMessageStream failed: %v", err)
+	}
+
+	var got *ChatStreamEvent
+	for event := range ch {
+		if event.Type == "error" {
+			e := event
+			got = &e
+		}
+	}
+	if got == nil {
+		t.Fatal("Expected error event")
+	}
+	if got.Error != "OpenAI API error 429 Too Many Requests" {
+		t.Errorf("Error = %q", got.Error)
+	}
+	if got.ErrorKind != "provider_rate_limited" {
+		t.Errorf("ErrorKind = %q, want provider_rate_limited", got.ErrorKind)
+	}
+	if got.Provider != "openai" {
+		t.Errorf("Provider = %q, want openai", got.Provider)
+	}
+	if got.ProviderStatus == nil || *got.ProviderStatus != 429 {
+		t.Errorf("ProviderStatus = %v, want 429", got.ProviderStatus)
+	}
+	if got.RetryAfterSecs == nil || *got.RetryAfterSecs != 7 {
+		t.Errorf("RetryAfterSecs = %v, want 7", got.RetryAfterSecs)
+	}
+	if !got.IsProviderFailure() {
+		t.Errorf("a classified error is a provider failure")
 	}
 }
 

--- a/chat_test.go
+++ b/chat_test.go
@@ -266,6 +266,42 @@ func TestChatMessageStreamError(t *testing.T) {
 	}
 }
 
+// A frame the server names `error` is an error whatever its payload calls
+// the message, so a `message`-only payload is an error event rather than a
+// frame to skip.
+func TestChatMessageStreamEventNamedErrorWithMessageOnly(t *testing.T) {
+	server := createTestServer(t, map[string]http.HandlerFunc{
+		"POST /api/chat/session_1/messages/stream": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, _ := w.(http.Flusher)
+			fmt.Fprintf(w, "event: token\ndata: {\"token\":\"Hel\"}\n\n")
+			fmt.Fprintf(w, "event: error\ndata: {\"message\":\"boom\"}\n\n")
+			flusher.Flush()
+		},
+	})
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	ch, err := client.ChatMessageStream(context.Background(), "session_1", ChatMessageRequest{Message: "Hi"})
+	if err != nil {
+		t.Fatalf("ChatMessageStream failed: %v", err)
+	}
+
+	var events []ChatStreamEvent
+	for event := range ch {
+		events = append(events, event)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected a chunk and an error, got %+v", events)
+	}
+	if events[0].Type != "chunk" || events[0].Content != "Hel" {
+		t.Fatalf("unexpected first event: %+v", events[0])
+	}
+	if events[1].Type != "error" || events[1].Error != "boom" || events[1].IsProviderFailure() {
+		t.Fatalf("unexpected error event: %+v", events[1])
+	}
+}
+
 // The deployment classifies a provider failure (error_kind, provider,
 // provider_status, retry_after_secs); the event carries every field so a
 // consumer can act on it without string-matching. A plain error stays bare.

--- a/client_test.go
+++ b/client_test.go
@@ -1056,6 +1056,77 @@ func TestGetChatModels(t *testing.T) {
 	if len(models.Anthropic) != 2 {
 		t.Errorf("Expected 2 Anthropic models, got %d", len(models.Anthropic))
 	}
+	if models.Providers != nil {
+		t.Errorf("a server without a providers map must leave Providers nil, got %v", models.Providers)
+	}
+}
+
+// GET /api/chat_models carries a gemini list and a per-provider status map
+// beside the three original lists, so a rejected key is distinguishable from
+// a missing one. The raw JSON below is the server's actual shape; encoding a
+// ChatModels literal would only prove the struct round-trips with itself.
+func TestGetChatModelsCarriesGeminiAndProviderStatus(t *testing.T) {
+	handlers := map[string]http.HandlerFunc{
+		"GET /api/chat_models": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"openai": [],
+				"anthropic": ["claude-sonnet-4-5"],
+				"perplexity": ["sonar"],
+				"gemini": ["gemini-2.5-flash"],
+				"providers": {
+					"anthropic": {"status": "ok", "verified": true, "model_count": 1},
+					"openai": {"status": "auth_failed", "verified": true, "http_status": 401,
+					           "message": "Failed to fetch OpenAI models: 401 Unauthorized"},
+					"perplexity": {"status": "ok", "verified": false,
+					               "message": "static model list; key not verified"}
+				}
+			}`))
+		},
+	}
+	server := createTestServer(t, handlers)
+	defer server.Close()
+
+	client := createTestClient(t, server)
+	models, err := client.GetChatModels()
+	if err != nil {
+		t.Fatalf("GetChatModels failed: %v", err)
+	}
+	if len(models.Gemini) != 1 || models.Gemini[0] != "gemini-2.5-flash" {
+		t.Errorf("Gemini = %v, want [gemini-2.5-flash]", models.Gemini)
+	}
+	openai, ok := models.Providers["openai"]
+	if !ok {
+		t.Fatalf("no openai row in Providers: %v", models.Providers)
+	}
+	if openai.Status != ChatProviderAuthFailed {
+		t.Errorf("openai.Status = %q, want %q", openai.Status, ChatProviderAuthFailed)
+	}
+	if !openai.Verified {
+		t.Errorf("a 401 is the provider's answer about this key: Verified must be true")
+	}
+	if openai.HTTPStatus == nil || *openai.HTTPStatus != 401 {
+		t.Errorf("openai.HTTPStatus = %v, want 401", openai.HTTPStatus)
+	}
+	if openai.Message == nil || *openai.Message != "Failed to fetch OpenAI models: 401 Unauthorized" {
+		t.Errorf("openai.Message = %v", openai.Message)
+	}
+	if openai.ModelCount != nil {
+		t.Errorf("openai.ModelCount = %v, want nil on a failure", openai.ModelCount)
+	}
+	if openai.IsUsable() {
+		t.Errorf("a rejected key is not usable")
+	}
+	anthropic := models.Providers["anthropic"]
+	if anthropic.Status != ChatProviderOK || anthropic.ModelCount == nil || *anthropic.ModelCount != 1 {
+		t.Errorf("anthropic = %+v, want ok with model_count 1", anthropic)
+	}
+	if !anthropic.IsUsable() {
+		t.Errorf("an ok provider is usable")
+	}
+	if models.Providers["perplexity"].Verified {
+		t.Errorf("perplexity is presence-checked only: Verified must be false")
+	}
 }
 
 func TestGetChatTools(t *testing.T) {

--- a/websocket.go
+++ b/websocket.go
@@ -76,9 +76,14 @@ func chatStreamErrorEvent(eventData map[string]interface{}) ChatStreamEvent {
 	} else {
 		ev.Error = "unknown error"
 	}
-	if k, ok := eventData["error_kind"].(string); ok {
-		ev.ErrorKind = k
+	// The classification travels as one unit: without an error_kind there
+	// is no provider failure, and the other fields stay empty even if the
+	// frame happened to carry them, so the struct matches its contract.
+	k, ok := eventData["error_kind"].(string)
+	if !ok || k == "" {
+		return ev
 	}
+	ev.ErrorKind = k
 	if p, ok := eventData["provider"].(string); ok {
 		ev.Provider = p
 	}
@@ -977,15 +982,17 @@ func (ws *WebSocketClient) routeChatStreamError(msg map[string]json.RawMessage) 
 	ws.mu.Unlock()
 
 	if ok {
+		event := ChatStreamEvent{Type: "error", Error: errMsg}
+		// As on the SSE route: the classification travels as one unit, and
+		// without an error_kind none of it is carried.
+		if payload.ErrorKind != "" {
+			event.ErrorKind = payload.ErrorKind
+			event.Provider = payload.Provider
+			event.ProviderStatus = payload.ProviderStatus
+			event.RetryAfterSecs = payload.RetryAfterSecs
+		}
 		select {
-		case ch <- ChatStreamEvent{
-			Type:           "error",
-			Error:          errMsg,
-			ErrorKind:      payload.ErrorKind,
-			Provider:       payload.Provider,
-			ProviderStatus: payload.ProviderStatus,
-			RetryAfterSecs: payload.RetryAfterSecs,
-		}:
+		case ch <- event:
 		default:
 		}
 		close(ch)

--- a/websocket.go
+++ b/websocket.go
@@ -38,6 +38,47 @@ type ChatStreamEvent struct {
 	ToolName        string          `json:"tool_name,omitempty"`
 	Arguments       json.RawMessage `json:"arguments,omitempty"`
 	Error           string          `json:"error,omitempty"`
+	// ErrorKind is the provider-failure classification ("provider_auth_failed",
+	// "provider_permission_denied", "provider_billing", "provider_rate_limited",
+	// "provider_unavailable", "provider_unreachable", "provider_not_configured",
+	// "provider_request_error") when the failure was the LLM provider's answer.
+	// Empty for a transport failure or a plain server error.
+	ErrorKind string `json:"error_kind,omitempty"`
+	Provider  string `json:"provider,omitempty"`
+	// ProviderStatus is the provider's own HTTP status, when it answered.
+	ProviderStatus *int   `json:"provider_status,omitempty"`
+	RetryAfterSecs *int64 `json:"retry_after_secs,omitempty"`
+}
+
+// IsProviderFailure reports whether an error event carries the server's
+// provider-failure classification — the case a caller can act on (fix the key,
+// wait, add credit).
+func (e ChatStreamEvent) IsProviderFailure() bool {
+	return e.Type == "error" && e.ErrorKind != ""
+}
+
+// chatStreamErrorEvent builds the error event for an SSE frame, carrying the
+// provider-failure classification when the frame has it.
+func chatStreamErrorEvent(eventData map[string]interface{}) ChatStreamEvent {
+	ev := ChatStreamEvent{Type: "error"}
+	if e, ok := eventData["error"].(string); ok {
+		ev.Error = e
+	}
+	if k, ok := eventData["error_kind"].(string); ok {
+		ev.ErrorKind = k
+	}
+	if p, ok := eventData["provider"].(string); ok {
+		ev.Provider = p
+	}
+	if s, ok := eventData["provider_status"].(float64); ok {
+		status := int(s)
+		ev.ProviderStatus = &status
+	}
+	if r, ok := eventData["retry_after_secs"].(float64); ok {
+		secs := int64(r)
+		ev.RetryAfterSecs = &secs
+	}
+	return ev
 }
 
 // ClientToolDefinition defines a client-side tool the LLM can call.
@@ -894,8 +935,12 @@ func (ws *WebSocketClient) routeChatStreamError(msg map[string]json.RawMessage) 
 	}
 
 	var payload struct {
-		Error   string `json:"error"`
-		Message string `json:"message"`
+		Error          string `json:"error"`
+		Message        string `json:"message"`
+		ErrorKind      string `json:"error_kind"`
+		Provider       string `json:"provider"`
+		ProviderStatus *int   `json:"provider_status"`
+		RetryAfterSecs *int64 `json:"retry_after_secs"`
 	}
 	if raw, ok := msg["payload"]; ok {
 		if err := json.Unmarshal(raw, &payload); err != nil {
@@ -921,7 +966,14 @@ func (ws *WebSocketClient) routeChatStreamError(msg map[string]json.RawMessage) 
 
 	if ok {
 		select {
-		case ch <- ChatStreamEvent{Type: "error", Error: errMsg}:
+		case ch <- ChatStreamEvent{
+			Type:           "error",
+			Error:          errMsg,
+			ErrorKind:      payload.ErrorKind,
+			Provider:       payload.Provider,
+			ProviderStatus: payload.ProviderStatus,
+			RetryAfterSecs: payload.RetryAfterSecs,
+		}:
 		default:
 		}
 		close(ch)

--- a/websocket.go
+++ b/websocket.go
@@ -65,11 +65,16 @@ func (e ChatStreamEvent) IsProviderFailure() bool {
 }
 
 // chatStreamErrorEvent builds the error event for an SSE frame, carrying the
-// provider-failure classification when the frame has it.
+// provider-failure classification when the frame has it. A payload that says
+// `message` instead of `error` is still the error, as on the WebSocket route.
 func chatStreamErrorEvent(eventData map[string]interface{}) ChatStreamEvent {
 	ev := ChatStreamEvent{Type: "error"}
-	if e, ok := eventData["error"].(string); ok {
+	if e, ok := eventData["error"].(string); ok && e != "" {
 		ev.Error = e
+	} else if m, ok := eventData["message"].(string); ok && m != "" {
+		ev.Error = m
+	} else {
+		ev.Error = "unknown error"
 	}
 	if k, ok := eventData["error_kind"].(string); ok {
 		ev.ErrorKind = k

--- a/websocket.go
+++ b/websocket.go
@@ -42,11 +42,18 @@ type ChatStreamEvent struct {
 	// "provider_permission_denied", "provider_billing", "provider_rate_limited",
 	// "provider_unavailable", "provider_unreachable", "provider_not_configured",
 	// "provider_request_error") when the failure was the LLM provider's answer.
-	// Empty for a transport failure or a plain server error.
+	// Empty when the server did not send one — a transport failure or a plain
+	// server error. The server never sends an empty kind, so like the other
+	// optional strings on this event (Content, ChatID, Error) the empty string
+	// is the absence marker; only the numeric fields below need a pointer,
+	// because 0 is a value there.
 	ErrorKind string `json:"error_kind,omitempty"`
-	Provider  string `json:"provider,omitempty"`
+	// Provider names the provider that answered ("openai", "anthropic",
+	// "perplexity", "gemini"); empty whenever ErrorKind is.
+	Provider string `json:"provider,omitempty"`
 	// ProviderStatus is the provider's own HTTP status, when it answered.
-	ProviderStatus *int   `json:"provider_status,omitempty"`
+	ProviderStatus *int `json:"provider_status,omitempty"`
+	// RetryAfterSecs is the provider's wait on a rate limit, when it gave one.
 	RetryAfterSecs *int64 `json:"retry_after_secs,omitempty"`
 }
 

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -420,6 +420,100 @@ func TestWebSocketChatStreamError(t *testing.T) {
 	}
 }
 
+// The WebSocket ChatStreamError payload carries the same classification as
+// the SSE error frame, and the event carries every field of it.
+func TestWebSocketChatStreamErrorCarriesTheClassification(t *testing.T) {
+	wsURL, connCh, server := setupTestWSServer(t)
+	defer server.Close()
+
+	client := &Client{token: "test-token"}
+	ws, err := client.WebSocket(wsURL)
+	if err != nil {
+		t.Fatalf("failed to create WebSocket client: %v", err)
+	}
+	defer ws.Close()
+
+	serverConn := <-connCh
+	defer serverConn.Close()
+
+	eventCh, err := ws.ChatSend("chat-3", "test")
+	if err != nil {
+		t.Fatalf("failed to send chat: %v", err)
+	}
+	readMessage(t, serverConn)
+
+	mustWriteJSON(t, serverConn, map[string]interface{}{
+		"type": "ChatStreamError",
+		"payload": map[string]interface{}{
+			"chat_id":          "chat-3",
+			"error":            "OpenAI API error 429 Too Many Requests",
+			"error_kind":       "provider_rate_limited",
+			"provider":         "openai",
+			"provider_status":  429,
+			"retry_after_secs": 7,
+		},
+	})
+
+	var events []ChatStreamEvent
+	for event := range eventCh {
+		events = append(events, event)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev.Type != "error" || ev.Error != "OpenAI API error 429 Too Many Requests" {
+		t.Fatalf("unexpected error event: %+v", ev)
+	}
+	if ev.ErrorKind != "provider_rate_limited" || ev.Provider != "openai" {
+		t.Fatalf("classification not carried: %+v", ev)
+	}
+	if ev.ProviderStatus == nil || *ev.ProviderStatus != 429 {
+		t.Fatalf("provider_status not carried: %+v", ev)
+	}
+	if ev.RetryAfterSecs == nil || *ev.RetryAfterSecs != 7 {
+		t.Fatalf("retry_after_secs not carried: %+v", ev)
+	}
+	if !ev.IsProviderFailure() {
+		t.Fatalf("a classified error is a provider failure: %+v", ev)
+	}
+}
+
+// A payload that says `message` instead of `error` is still the error.
+func TestWebSocketChatStreamErrorFallsBackToMessage(t *testing.T) {
+	wsURL, connCh, server := setupTestWSServer(t)
+	defer server.Close()
+
+	client := &Client{token: "test-token"}
+	ws, err := client.WebSocket(wsURL)
+	if err != nil {
+		t.Fatalf("failed to create WebSocket client: %v", err)
+	}
+	defer ws.Close()
+
+	serverConn := <-connCh
+	defer serverConn.Close()
+
+	eventCh, err := ws.ChatSend("chat-4", "test")
+	if err != nil {
+		t.Fatalf("failed to send chat: %v", err)
+	}
+	readMessage(t, serverConn)
+
+	mustWriteJSON(t, serverConn, map[string]interface{}{
+		"type":    "ChatStreamError",
+		"payload": map[string]interface{}{"chat_id": "chat-4", "message": "boom"},
+	})
+
+	var events []ChatStreamEvent
+	for event := range eventCh {
+		events = append(events, event)
+	}
+	if len(events) != 1 || events[0].Type != "error" || events[0].Error != "boom" || events[0].IsProviderFailure() {
+		t.Fatalf("unexpected events: %+v", events)
+	}
+}
+
 func TestWebSocketRegisterClientTools(t *testing.T) {
 	wsURL, connCh, server := setupTestWSServer(t)
 	defer server.Close()

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -479,6 +479,51 @@ func TestWebSocketChatStreamErrorCarriesTheClassification(t *testing.T) {
 	}
 }
 
+// Without `error_kind` the WebSocket route carries no classification either.
+func TestWebSocketChatStreamErrorWithoutKindCarriesNoClassification(t *testing.T) {
+	wsURL, connCh, server := setupTestWSServer(t)
+	defer server.Close()
+
+	client := &Client{token: "test-token"}
+	ws, err := client.WebSocket(wsURL)
+	if err != nil {
+		t.Fatalf("failed to create WebSocket client: %v", err)
+	}
+	defer ws.Close()
+
+	serverConn := <-connCh
+	defer serverConn.Close()
+
+	eventCh, err := ws.ChatSend("chat-5", "test")
+	if err != nil {
+		t.Fatalf("failed to send chat: %v", err)
+	}
+	readMessage(t, serverConn)
+
+	mustWriteJSON(t, serverConn, map[string]interface{}{
+		"type": "ChatStreamError",
+		"payload": map[string]interface{}{
+			"chat_id":          "chat-5",
+			"error":            "Model unavailable",
+			"provider":         "openai",
+			"provider_status":  503,
+			"retry_after_secs": 5,
+		},
+	})
+
+	var events []ChatStreamEvent
+	for event := range eventCh {
+		events = append(events, event)
+	}
+	if len(events) != 1 || events[0].Type != "error" || events[0].Error != "Model unavailable" {
+		t.Fatalf("expected one plain error event, got %+v", events)
+	}
+	ev := events[0]
+	if ev.ErrorKind != "" || ev.Provider != "" || ev.ProviderStatus != nil || ev.RetryAfterSecs != nil || ev.IsProviderFailure() {
+		t.Fatalf("a payload without error_kind must carry no classification: %+v", ev)
+	}
+}
+
 // A payload that says `message` instead of `error` is still the error.
 func TestWebSocketChatStreamErrorFallsBackToMessage(t *testing.T) {
 	wsURL, connCh, server := setupTestWSServer(t)


### PR DESCRIPTION
Closes #61.

## What

`GET /api/chat_models` now returns a `gemini` list and a per-provider `providers` status map, and a failed chat stream carries the server's provider-failure classification.

- `ChatModels.Gemini []string` and `ChatModels.Providers map[string]ChatProviderStatus` (`ChatProviderState` constants for the nine documented states — an unknown state decodes as its raw string — and `IsUsable()`). Both `omitempty`, nil from an older server.
- `ChatStreamEvent` gains `ErrorKind` and `Provider` (strings, empty when not sent — the same absence marker as the event's other optional strings), `ProviderStatus` and `RetryAfterSecs` (pointers, since 0 is a value there), and `IsProviderFailure()`, on both SSE and WebSocket streams. A plain error stays bare.

Pairs with the server-side change, tracked internally.

## Verification

- `go test ./...` — ok (decoding the real wire shape, the old three-list shape, SSE error frames with and without the classification). `go vet ./...` — ok. `gofmt -l .` — clean.
- The chat-models example builds and vets against this client (`go build`/`go vet client_chat_models.go` under a workspace `replace`).
- README + CHANGELOG `[Unreleased]`; no version bump.

