### PR TITLE
fix(search): expose execution time metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.2] - 2026-09-08
+
+### Fixed
+
+- **Search responses now expose `execution_time_ms`.** The Go client previously
+  only modeled the obsolete `took_ms` key, so the server's execution timing was
+  silently discarded. `TookMs` remains for compatibility with older response
+  shapes; Go callers should use `ExecutionTimeMs` for the ekoDB contract.
+
 ## [0.26.1] - 2026-09-07
 
 ### Fixed

--- a/client_test.go
+++ b/client_test.go
@@ -1477,7 +1477,8 @@ func TestSearchSuccess(t *testing.T) {
 					{"id": "doc_1", "score": 0.95, "title": "Result 1"},
 					{"id": "doc_2", "score": 0.85, "title": "Result 2"},
 				},
-				"total": 2,
+				"total":             2,
+				"execution_time_ms": 12,
 			})
 		},
 	}
@@ -1492,6 +1493,9 @@ func TestSearchSuccess(t *testing.T) {
 	}
 	if len(result.Results) != 2 {
 		t.Errorf("Search returned %d results, want 2", len(result.Results))
+	}
+	if result.ExecutionTimeMs == nil || *result.ExecutionTimeMs != 12 {
+		t.Fatalf("Search execution time = %v, want 12ms", result.ExecutionTimeMs)
 	}
 }
 

--- a/search.go
+++ b/search.go
@@ -61,7 +61,11 @@ type SearchResult struct {
 type SearchResponse struct {
 	Results []SearchResult `json:"results"`
 	Total   int            `json:"total"`
-	TookMs  *int           `json:"took_ms,omitempty"`
+	// ExecutionTimeMs is the server-reported search execution time.
+	ExecutionTimeMs *int `json:"execution_time_ms,omitempty"`
+	// TookMs is retained for compatibility with older/non-ekoDB response shapes.
+	// Deprecated: use ExecutionTimeMs for the ekoDB search response contract.
+	TookMs *int `json:"took_ms,omitempty"`
 }
 
 // SearchQueryBuilder provides a fluent API for building search queries


### PR DESCRIPTION
## Summary

Expose the ekoDB search response’s `execution_time_ms` metadata in the Go client.

The Go client already supports the typed text/vector/hybrid search surface, filters, projections, JSON search transport, retries, and existing legacy helpers. During the post-merge parity audit for [ekoDB/ekodb-client#208](https://github.com/ekoDB/ekodb-client/pull/208), we found that Go modeled the obsolete `took_ms` key and silently discarded the server’s execution timing.

## Changes

- Add `SearchResponse.ExecutionTimeMs` mapped to `execution_time_ms`.
- Retain `TookMs` for compatibility with older/non-ekoDB response shapes and mark it deprecated in documentation.
- Add regression coverage proving `execution_time_ms` is decoded.
- Prepare the Go client’s `0.26.2` patch changelog entry.

## Validation

- `gofmt` and `git diff --check` passed.
- `go test ./...` passed using the repository code and a temporary compatibility module file because the audit environment’s installed Go toolchain was older than the repository’s declared version. The repository’s `go.mod` was not changed for that workaround.
- All PR checks are green: Go tests, lint, CodeQL, and static analysis.

## Release coordination

The coordinated `0.26.2` bump for the Rust, Python, TypeScript, and Kotlin clients has merged in [ekoDB/ekodb-client#210](https://github.com/ekoDB/ekodb-client/pull/210). This PR is the remaining Go-client follow-up for that patch release.

Tracking: [ekoDB/ekodb-client#209](https://github.com/ekoDB/ekodb-client/issues/209)

This is a narrow compatibility-preserving metadata fix. It does not change request serialization, search ranking, retry behavior, or legacy helper signatures.
