### PR TITLE
chore(*): v0.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.3] - 2026-09-10
+
+### Changed
+
+- **Coordinated client patch release.** Version aligned with `ekodb-client`
+  0.26.3, which carries the Kotlin schema-type, `Vector` record serialization
+  and HTTP error fixes plus a compatible dependency refresh. No Go client
+  changes; `gorilla/websocket` 1.5.3 and `msgpack/v5` 5.4.1 were checked and are
+  already the latest releases.
+
 ## [0.26.2] - 2026-09-08
 
 ### Fixed


### PR DESCRIPTION
## What & why

Release cap `v0.26.3` for the Go client, in step with ekodb-client#218 so both clients carry the same version. Refs ekoDB/ekodb-client#215.

Version: `0.26.3` (was `0.26.2`). This repo has no version file; the version is the git tag, cut from `main` on this commit after merge, as the `v0.26.2` tag was on the previous cap commit. The only change is the `[0.26.3] - 2026-09-10` changelog block, which states that there are no Go client changes and that `make deps-update` found both direct modules already at their latest releases.

## Reviewer checklist (before merge)

- [ ] Changelog block added above `[0.26.2]`; released blocks untouched.
- [ ] After merge: `git tag -a v0.26.3 -m "Release v0.26.3" <merge commit>` from `main`, then `git push origin v0.26.3` (no `release.yml` here, so the tag is cut by hand).

## Verification evidence

`git diff origin/main` is the changelog block only. `make test` with Go 1.27.1 at this head (a74ea61): 448 tests, all passed. The cap commit was amended once to match the markdown formatter's wrap.

<!-- pr-queue: proven a74ea618ad858caada76338ae08c84e367f81ad4 -->
