### PR TITLE
fix(release): make a pushed tag visible on pkg.go.dev instead of waiting for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ and this project adheres to
   `pkg.go.dev/github.com/ekoDB/ekodb-client-go` still listed `v0.26.0` as the
   latest, for three days in the first case. `scripts/index-release.sh` requests
   the version from the proxy, asks pkg.go.dev to fetch it, and polls the version
-  page until it renders, failing with the URL and status otherwise. `publish.sh`
-  runs it after the tag push, `make index-release VERSION=vX.Y.Z` runs it alone,
+  page until it renders, failing with the URL and status otherwise; every
+  request carries a timeout, the proxy step retries within the same budget
+  because its first fetch from origin is not instant after a push, and invalid
+  poll settings are rejected before any request. `publish.sh` runs it after the
+  tag push, `make index-release VERSION=vX.Y.Z` runs it alone,
   `make bump-version` names it in its next steps, and `PUBLISHING.md` now
   describes the current single-repository release rather than a planned move out
   of a monorepo. Covered by `scripts/index_release_test.go`, which drives the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Releases are now made visible on pkg.go.dev instead of waiting for it.**
+  Neither the module proxy nor pkg.go.dev watches GitHub, and the release flow
+  only told the releaser to "wait a few minutes": `v0.26.1` through `v0.26.3`
+  sat on GitHub and on `proxy.golang.org` while
+  `pkg.go.dev/github.com/ekoDB/ekodb-client-go` still listed `v0.26.0` as the
+  latest, for three days in the first case. `scripts/index-release.sh` requests
+  the version from the proxy, asks pkg.go.dev to fetch it, and polls the version
+  page until it renders, failing with the URL and status otherwise. `publish.sh`
+  runs it after the tag push, `make index-release VERSION=vX.Y.Z` runs it alone,
+  `make bump-version` names it in its next steps, and `PUBLISHING.md` now
+  describes the current single-repository release rather than a planned move out
+  of a monorepo. Covered by `scripts/index_release_test.go`, which drives the
+  script against local stand-ins for both services. (#70)
+
 ## [0.26.3] - 2026-09-10
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ JET := "                    $(MAGENTA)●$(RESET)\n                    $(PURPLE)
 # ASCII Banner for ekoDB (matches CLI banner)
 BANNER := "$(BOLD) ██████═╗ ██╗  ██╗  ██████╗  ████████╗ ████████╗$(RESET)\n$(BOLD)██╔═══██╝ ██║ ██╔╝ ██╔═══██╗  ██╔═══██║ ██╔═══██╗$(RESET)\n$(BOLD)████████╗ █████╔╝  ██║   ██║  ██║   ██║████████╔╝$(RESET)\n$(BOLD)██╔═════╝ ██╔═██╗  ██║   ██║  ██║   ██║ ██╔═══██╗$(RESET)\n$(BOLD)████████╗ ██║  ██╗ ╚██████╔╝ ████████║ ████████╔╝$(RESET)\n$(BOLD)╚═══════╝ ╚═╝  ╚═╝  ╚═════╝  ╚═══════╝ ╚═══════╝$(RESET)"
 
-.PHONY: all build test test-verbose test-coverage clean fmt fmt-go fmt-md fmt-check format lint lint-fix ensure-golangci-lint vet mod-tidy mod-verify mod-download install help setup deps-check deps-update publish bump-version check-ready examples pre-commit ensure-hooks version info
+.PHONY: all build test test-verbose test-coverage clean fmt fmt-go fmt-md fmt-check format lint lint-fix ensure-golangci-lint vet mod-tidy mod-verify mod-download install help setup deps-check deps-update publish bump-version index-release check-ready examples pre-commit ensure-hooks version info
 
 # Language Sub-Banner
 GO_BANNER := \
@@ -71,6 +71,7 @@ help:
 	@echo "$(CYAN)━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━$(RESET)"
 	@echo "  🚀 $(GREEN)make publish$(RESET)        - Publish new version (runs publish.sh)"
 	@echo "  🔢 $(GREEN)make bump-version$(RESET)   - Bump version and create git tag"
+	@echo "  📚 $(GREEN)make index-release$(RESET)  - Make a pushed tag visible on pkg.go.dev (VERSION=vX.Y.Z)"
 	@echo "  ✅ $(GREEN)make check-ready$(RESET)    - Check if ready to publish"
 	@echo ""
 	@echo "$(CYAN)━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━$(RESET)"
@@ -321,8 +322,14 @@ bump-version:
 	echo "$(YELLOW)💡 Next steps:$(RESET)"; \
 	echo "  1. Push tag: git push origin $$NEW_VERSION"; \
 	echo "  2. Push commits: git push origin main"; \
-	echo "  3. Wait for pkg.go.dev to index (a few minutes)"; \
+	echo "  3. Make it visible on pkg.go.dev: make index-release VERSION=$$NEW_VERSION"; \
 	echo "  4. Users can install: go get $(MODULE)@$$NEW_VERSION"
+
+# Neither the module proxy nor pkg.go.dev watches GitHub, so a pushed tag is
+# not on pkg.go.dev until something asks for it. This runs the three requests
+# that make it appear and succeeds only once the version page renders.
+index-release: ## Make a pushed tag visible on pkg.go.dev (VERSION=vX.Y.Z)
+	@bash scripts/index-release.sh "$(VERSION)"
 
 # Run example programs from ekodb-client repository
 test-examples:

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,84 +1,60 @@
 # Publishing ekoDB Go Client
 
-This Go client will be moved to a separate public repository for distribution
-via Go modules.
+The client is distributed as a Go module from this repository. A release is a
+semantic-version tag on `main`; there is no registry upload.
 
-## Current Status
-
-🚧 **In Development** - Currently part of the ekoDB monorepo
-
-## Future Publishing Strategy
-
-### When Moving to Separate Repository
-
-1. **Create Public Repository**
-
-   ```bash
-   # Create new repo at: github.com/ekoDB/ekodb-client-go
-   ```
-
-2. **Copy Files**
-
-   ```bash
-   # Copy all Go client files to the new repository
-   cp -r ekodb-client-go/* /path/to/new/ekodb-client-go/
-   ```
-
-3. **Initialize and Push**
-
-   ```bash
-   cd /path/to/new/ekodb-client-go
-   git init
-   git add .
-   git commit -m "Initial commit: ekoDB Go client"
-   git remote add origin git@github.com:ekoDB/ekodb-client-go.git
-   git push -u origin main
-   ```
-
-4. **Tag and Publish**
-
-   ```bash
-   # Use the publish.sh script
-   ./publish.sh
-
-   # Or manually:
-   git tag v0.1.0
-   git push origin v0.1.0
-   ```
-
-## Publishing from Separate Repository
-
-Once in its own repository, use the `publish.sh` script:
+## Release
 
 ```bash
-./publish.sh
+make publish
 ```
 
-This script will:
+`make publish` runs `check-ready` (format check, `go vet`, the test suite, and a
+clean working tree) and then `publish.sh`, which:
 
-- Run tests
-- Create a semantic version tag
-- Push the tag to GitHub
-- Automatically indexed by pkg.go.dev
+1. runs the tests and `go mod tidy`
+2. prompts for the new version (`vX.Y.Z`) and creates an annotated tag
+3. pushes the tag, and optionally `main`
+4. runs `scripts/index-release.sh`, which makes the tag visible on pkg.go.dev
 
-## Installation (After Publishing)
+## Why step 4 exists
 
-Users will install with:
+Neither the Go module proxy nor pkg.go.dev watches GitHub. The proxy fetches a
+version the first time something asks for it, and pkg.go.dev indexes a version
+when it is asked to. Left alone, a pushed tag can sit for days while
+<https://pkg.go.dev/github.com/ekoDB/ekodb-client-go> still shows the previous
+release, and `@latest` on the proxy disagrees with the page.
+
+`scripts/index-release.sh vX.Y.Z` performs the three requests in order and
+succeeds only once the version page renders:
+
+1. `GET https://proxy.golang.org/github.com/eko!d!b/ekodb-client-go/@v/vX.Y.Z.info`
+   (the proxy's case-encoded module path) so the proxy fetches the tag
+2. `POST https://pkg.go.dev/fetch/github.com/ekoDB/ekodb-client-go@vX.Y.Z` so
+   pkg.go.dev indexes it
+3. `GET https://pkg.go.dev/github.com/ekoDB/ekodb-client-go@vX.Y.Z` until it
+   returns 200
+
+It can be run on its own for a tag that was pushed some other way:
 
 ```bash
-go get github.com/ekoDB/ekodb-client-go@v0.1.0
+make index-release VERSION=vX.Y.Z
 ```
 
-## Why Separate Repository?
+It exits non-zero, naming the URL and HTTP status, when the proxy does not serve
+the version (the tag is not on origin, or points at a commit without a
+`go.mod`), when pkg.go.dev reports the version as not found, or when the page
+has not rendered after `INDEX_ATTEMPTS` polls `INDEX_SLEEP` seconds apart
+(defaults 30 and 10). Its tests live in `scripts/index_release_test.go` and run
+as part of `go test ./...`.
 
-Go modules work best with dedicated repositories because:
+## Tagging without publishing
 
-- Go pulls the entire repository by default
-- Keeping it separate prevents users from downloading the server code
-- Standard practice in the Go ecosystem
-- Cleaner dependency management
+`make bump-version` runs the tests and creates the tag locally without pushing
+anything; it prints the push and `make index-release` commands to run next.
 
-## Current Development
+## Installation
 
-For now, the Go client is developed in the monorepo alongside other clients. The
-`publish.sh` script is ready for when we move to a separate repository.
+```bash
+go get github.com/ekoDB/ekodb-client-go@vX.Y.Z
+```

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -61,8 +61,8 @@ It can be run on its own for a tag that was pushed some other way:
 make index-release VERSION=vX.Y.Z
 ```
 
-It exits 1, naming the URL and HTTP status (with curl's own message when no
-status was obtained), when the proxy has not served the version after
+It exits 1, naming the URL and HTTP status (with curl's own message when the
+request did not complete), when the proxy has not served the version after
 `INDEX_ATTEMPTS` polls `INDEX_SLEEP` seconds apart (the tag is not on origin, or
 points at a commit without a `go.mod`), when pkg.go.dev reports the version as
 not found, or when the page has not rendered after the same number of polls. The

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -46,8 +46,14 @@ succeeds only once the version page renders:
 3. `GET https://pkg.go.dev/github.com/ekoDB/ekodb-client-go@vX.Y.Z` until it
    returns 200
 
-Every request has a connect timeout of 10 seconds and an overall timeout of 30,
-so an unresponsive server ends the run instead of hanging it.
+Every request has a connect timeout of 10 seconds and an overall timeout of 30
+(`CONNECT_TIMEOUT` and `REQUEST_TIMEOUT`), so an unresponsive server ends the
+run instead of hanging it. The bound is per request, not per run: each polled
+step can take up to `INDEX_ATTEMPTS x (REQUEST_TIMEOUT + INDEX_SLEEP)`, about 20
+minutes at the defaults against a server that never answers. A tag that is not
+on origin costs the full `INDEX_ATTEMPTS x INDEX_SLEEP`, five minutes at the
+defaults, before step 1 gives up, because the proxy's 404 for a tag it has not
+fetched yet is the same 404 it gives for one that does not exist.
 
 It can be run on its own for a tag that was pushed some other way:
 
@@ -60,10 +66,11 @@ status was obtained), when the proxy has not served the version after
 `INDEX_ATTEMPTS` polls `INDEX_SLEEP` seconds apart (the tag is not on origin, or
 points at a commit without a `go.mod`), when pkg.go.dev reports the version as
 not found, or when the page has not rendered after the same number of polls. The
-defaults are 30 attempts and 10 seconds; both must be integers, and the script
-exits 2 before any request when they are not, or when the version is not of the
-form `vX.Y.Z`. Its tests live in `scripts/index_release_test.go` and run as part
-of `go test ./...`.
+defaults are 30 attempts and 10 seconds. `INDEX_ATTEMPTS`, `CONNECT_TIMEOUT` and
+`REQUEST_TIMEOUT` must be integers of at least 1 and `INDEX_SLEEP` an integer of
+at least 0, written as plain decimals; the script exits 2 before any request
+when they are not, or when the version is not of the form `vX.Y.Z`. Its tests
+live in `scripts/index_release_test.go` and run as part of `go test ./...`.
 
 ## Tagging without publishing
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -51,9 +51,9 @@ Every request has a connect timeout of 10 seconds and an overall timeout of 30
 run instead of hanging it. The bound is per request, not per run: each polled
 step can take up to `INDEX_ATTEMPTS x (REQUEST_TIMEOUT + INDEX_SLEEP)`, about 20
 minutes at the defaults against a server that never answers. A tag that is not
-on origin costs the full `INDEX_ATTEMPTS x INDEX_SLEEP`, five minutes at the
-defaults, before step 1 gives up, because the proxy's 404 for a tag it has not
-fetched yet is the same 404 it gives for one that does not exist.
+on origin costs `(INDEX_ATTEMPTS - 1) x INDEX_SLEEP`, just under five minutes at
+the defaults, before step 1 gives up, because the proxy's 404 for a tag it has
+not fetched yet is the same 404 it gives for one that does not exist.
 
 It can be run on its own for a tag that was pushed some other way:
 
@@ -67,10 +67,11 @@ status was obtained), when the proxy has not served the version after
 points at a commit without a `go.mod`), when pkg.go.dev reports the version as
 not found, or when the page has not rendered after the same number of polls. The
 defaults are 30 attempts and 10 seconds. `INDEX_ATTEMPTS`, `CONNECT_TIMEOUT` and
-`REQUEST_TIMEOUT` must be integers of at least 1 and `INDEX_SLEEP` an integer of
-at least 0, written as plain decimals; the script exits 2 before any request
-when they are not, or when the version is not of the form `vX.Y.Z`. Its tests
-live in `scripts/index_release_test.go` and run as part of `go test ./...`.
+`REQUEST_TIMEOUT` must be integers from 1 to 99999 and `INDEX_SLEEP` an integer
+from 0 to 99999, written as plain decimals; the script exits 2 before any
+request when they are not, or when the version is not of the form `vX.Y.Z`. Its
+tests live in `scripts/index_release_test.go` and run as part of
+`go test ./...`.
 
 ## Tagging without publishing
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -14,8 +14,18 @@ clean working tree) and then `publish.sh`, which:
 
 1. runs the tests and `go mod tidy`
 2. prompts for the new version (`vX.Y.Z`) and creates an annotated tag
-3. pushes the tag, and optionally `main`
+3. pushes the tag
 4. runs `scripts/index-release.sh`, which makes the tag visible on pkg.go.dev
+5. offers to push `main`
+
+`publish.sh` runs under `set -e`, so a failure in step 4 stops the run there:
+the tag is already on origin and `main` has not been pushed. Nothing needs
+undoing. Fix whatever the printed URL and status point at, then finish by hand:
+
+```bash
+make index-release VERSION=vX.Y.Z
+git push origin main
+```
 
 ## Why step 4 exists
 
@@ -29,11 +39,15 @@ release, and `@latest` on the proxy disagrees with the page.
 succeeds only once the version page renders:
 
 1. `GET https://proxy.golang.org/github.com/eko!d!b/ekodb-client-go/@v/vX.Y.Z.info`
-   (the proxy's case-encoded module path) so the proxy fetches the tag
+   (the proxy's case-encoded module path) until it returns 200, so the proxy
+   fetches the tag; the first fetch from origin is not instant after a push
 2. `POST https://pkg.go.dev/fetch/github.com/ekoDB/ekodb-client-go@vX.Y.Z` so
    pkg.go.dev indexes it
 3. `GET https://pkg.go.dev/github.com/ekoDB/ekodb-client-go@vX.Y.Z` until it
    returns 200
+
+Every request has a connect timeout of 10 seconds and an overall timeout of 30,
+so an unresponsive server ends the run instead of hanging it.
 
 It can be run on its own for a tag that was pushed some other way:
 
@@ -41,12 +55,15 @@ It can be run on its own for a tag that was pushed some other way:
 make index-release VERSION=vX.Y.Z
 ```
 
-It exits non-zero, naming the URL and HTTP status, when the proxy does not serve
-the version (the tag is not on origin, or points at a commit without a
-`go.mod`), when pkg.go.dev reports the version as not found, or when the page
-has not rendered after `INDEX_ATTEMPTS` polls `INDEX_SLEEP` seconds apart
-(defaults 30 and 10). Its tests live in `scripts/index_release_test.go` and run
-as part of `go test ./...`.
+It exits 1, naming the URL and HTTP status (with curl's own message when no
+status was obtained), when the proxy has not served the version after
+`INDEX_ATTEMPTS` polls `INDEX_SLEEP` seconds apart (the tag is not on origin, or
+points at a commit without a `go.mod`), when pkg.go.dev reports the version as
+not found, or when the page has not rendered after the same number of polls. The
+defaults are 30 attempts and 10 seconds; both must be integers, and the script
+exits 2 before any request when they are not, or when the version is not of the
+form `vX.Y.Z`. Its tests live in `scripts/index_release_test.go` and run as part
+of `go test ./...`.
 
 ## Tagging without publishing
 

--- a/publish.sh
+++ b/publish.sh
@@ -117,6 +117,12 @@ echo ""
 echo "🚀 Pushing tag to remote..."
 git push origin "$NEW_VERSION"
 
+# Neither the module proxy nor pkg.go.dev watches GitHub: without these
+# requests the tag can sit unindexed for days. Fails if the page never renders.
+echo ""
+echo "📚 Making $NEW_VERSION visible on pkg.go.dev..."
+"$SCRIPT_DIR/scripts/index-release.sh" "$NEW_VERSION"
+
 # Also push main branch if needed
 echo ""
 read -p "Push main branch too? (y/N): " -n 1 -r
@@ -129,5 +135,3 @@ echo ""
 echo "✅ Successfully published ekodb-client-go $NEW_VERSION!"
 echo "📦 Users can install with: go get $MODULE@$NEW_VERSION"
 echo "📚 Documentation available at: https://pkg.go.dev/$MODULE@$NEW_VERSION"
-echo ""
-echo "Note: It may take a few minutes for pkg.go.dev to index the new version."

--- a/scripts/index-release.sh
+++ b/scripts/index-release.sh
@@ -17,8 +17,9 @@
 # first fetch from origin is not instant, step 3 because pkg.go.dev processes
 # the fetch asynchronously. Every request carries a timeout, so a server that
 # accepts the connection and never answers cannot hang a release. The worst
-# case per polled step is INDEX_ATTEMPTS x (REQUEST_TIMEOUT + INDEX_SLEEP),
-# about 20 minutes at the defaults against a server that never answers, and a
+# case per polled step is at most INDEX_ATTEMPTS x REQUEST_TIMEOUT plus
+# (INDEX_ATTEMPTS - 1) x INDEX_SLEEP, just under 20 minutes at the defaults
+# against a server that never answers, and a
 # tag that is not on origin costs (INDEX_ATTEMPTS - 1) x INDEX_SLEEP, just
 # under five minutes at the defaults, before step 1 gives up: the proxy's 404
 # for a tag it has not fetched yet is the same 404 it gives for one that does
@@ -102,10 +103,13 @@ escape_module() {
 curl_stderr="$(mktemp)"
 trap 'rm -f "$curl_stderr"' EXIT
 
-# request <method> <url>: sets `code` to the HTTP status, or to 000 with
-# `detail` carrying curl's own message when no status was obtained (refused
-# connection, DNS failure, timeout). The two causes are kept apart so a network
-# failure never reads as a 404 and vice versa.
+# request <method> <url>: sets `code` to the HTTP status of a request that
+# completed, or to 000 with `detail` carrying curl's own message when it did
+# not (refused connection, DNS failure, a timeout before the status arrived,
+# or a transfer that started and then stalled past REQUEST_TIMEOUT, whose
+# partial status is discarded: an answer that never finished is not a render).
+# The two outcomes are kept apart so a network failure never reads as a 404
+# and vice versa.
 code=""
 detail=""
 request() {

--- a/scripts/index-release.sh
+++ b/scripts/index-release.sh
@@ -16,7 +16,12 @@
 # apart: step 1 because it runs seconds after the tag push and the proxy's
 # first fetch from origin is not instant, step 3 because pkg.go.dev processes
 # the fetch asynchronously. Every request carries a timeout, so a server that
-# accepts the connection and never answers cannot hang a release.
+# accepts the connection and never answers cannot hang a release. The worst
+# case per polled step is INDEX_ATTEMPTS x (REQUEST_TIMEOUT + INDEX_SLEEP),
+# about 20 minutes at the defaults against a server that never answers, and a
+# tag that is not on origin costs the full INDEX_ATTEMPTS x INDEX_SLEEP (five
+# minutes at the defaults) before step 1 gives up: the proxy's 404 for a tag it
+# has not fetched yet is the same 404 it gives for one that does not exist.
 #
 # Usage: scripts/index-release.sh vX.Y.Z
 #
@@ -25,6 +30,8 @@
 #   PKGSITE_URL     default https://pkg.go.dev
 #   INDEX_ATTEMPTS  polls per polled step, an integer >= 1 (default 30)
 #   INDEX_SLEEP     seconds between polls, an integer >= 0 (default 10)
+#   CONNECT_TIMEOUT seconds to establish each connection, >= 1 (default 10)
+#   REQUEST_TIMEOUT seconds for each whole request, >= 1 (default 30)
 #
 # Exit codes: 0 indexed; 1 a request failed (the URL and status are printed,
 # with curl's own message when the request could not be made at all); 2 bad
@@ -35,26 +42,34 @@ GOPROXY_URL="${GOPROXY_URL:-https://proxy.golang.org}"
 PKGSITE_URL="${PKGSITE_URL:-https://pkg.go.dev}"
 INDEX_ATTEMPTS="${INDEX_ATTEMPTS:-30}"
 INDEX_SLEEP="${INDEX_SLEEP:-10}"
-CONNECT_TIMEOUT=10
-REQUEST_TIMEOUT=30
+CONNECT_TIMEOUT="${CONNECT_TIMEOUT:-10}"
+REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-30}"
 
 version="${1:-}"
 if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "usage: $0 vX.Y.Z (got '${version}')" >&2
   exit 2
 fi
-if [[ ! "$INDEX_ATTEMPTS" =~ ^[0-9]+$ ]] || (( INDEX_ATTEMPTS < 1 )); then
-  echo "INDEX_ATTEMPTS must be an integer >= 1 (got '${INDEX_ATTEMPTS}')" >&2
-  exit 2
-fi
-if [[ ! "$INDEX_SLEEP" =~ ^[0-9]+$ ]]; then
+# The settings are matched as decimal digit strings with no leading zero, and
+# never evaluated arithmetically here: bash reads "08" as octal and errors,
+# and an error inside an `||` chain would skip the check instead of failing it.
+for setting in INDEX_ATTEMPTS CONNECT_TIMEOUT REQUEST_TIMEOUT; do
+  if [[ ! "${!setting}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "${setting} must be an integer >= 1 (got '${!setting}')" >&2
+    exit 2
+  fi
+done
+if [[ ! "$INDEX_SLEEP" =~ ^(0|[1-9][0-9]*)$ ]]; then
   echo "INDEX_SLEEP must be an integer >= 0 (got '${INDEX_SLEEP}')" >&2
   exit 2
 fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 go_mod="${script_dir}/../go.mod"
-module="$(awk '$1 == "module" { print $2; exit }' "$go_mod")"
+module=""
+if [[ -f "$go_mod" ]]; then
+  module="$(awk '$1 == "module" { print $2; exit }' "$go_mod")"
+fi
 if [[ -z "$module" ]]; then
   echo "could not read the module path from ${go_mod}" >&2
   exit 1

--- a/scripts/index-release.sh
+++ b/scripts/index-release.sh
@@ -19,19 +19,20 @@
 # accepts the connection and never answers cannot hang a release. The worst
 # case per polled step is INDEX_ATTEMPTS x (REQUEST_TIMEOUT + INDEX_SLEEP),
 # about 20 minutes at the defaults against a server that never answers, and a
-# tag that is not on origin costs the full INDEX_ATTEMPTS x INDEX_SLEEP (five
-# minutes at the defaults) before step 1 gives up: the proxy's 404 for a tag it
-# has not fetched yet is the same 404 it gives for one that does not exist.
+# tag that is not on origin costs (INDEX_ATTEMPTS - 1) x INDEX_SLEEP, just
+# under five minutes at the defaults, before step 1 gives up: the proxy's 404
+# for a tag it has not fetched yet is the same 404 it gives for one that does
+# not exist.
 #
 # Usage: scripts/index-release.sh vX.Y.Z
 #
 # Environment (overridable, used by the tests to point at local stubs):
 #   GOPROXY_URL     default https://proxy.golang.org
 #   PKGSITE_URL     default https://pkg.go.dev
-#   INDEX_ATTEMPTS  polls per polled step, an integer >= 1 (default 30)
-#   INDEX_SLEEP     seconds between polls, an integer >= 0 (default 10)
-#   CONNECT_TIMEOUT seconds to establish each connection, >= 1 (default 10)
-#   REQUEST_TIMEOUT seconds for each whole request, >= 1 (default 30)
+#   INDEX_ATTEMPTS  polls per polled step, 1 to 99999 (default 30)
+#   INDEX_SLEEP     seconds between polls, 0 to 99999 (default 10)
+#   CONNECT_TIMEOUT seconds to establish each connection, 1 to 99999 (default 10)
+#   REQUEST_TIMEOUT seconds for each whole request, 1 to 99999 (default 30)
 #
 # Exit codes: 0 indexed; 1 a request failed (the URL and status are printed,
 # with curl's own message when the request could not be made at all); 2 bad
@@ -50,17 +51,19 @@ if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "usage: $0 vX.Y.Z (got '${version}')" >&2
   exit 2
 fi
-# The settings are matched as decimal digit strings with no leading zero, and
-# never evaluated arithmetically here: bash reads "08" as octal and errors,
-# and an error inside an `||` chain would skip the check instead of failing it.
+# The settings are matched as decimal digit strings with no leading zero and
+# at most five digits, and never evaluated arithmetically here: bash reads
+# "08" as octal and errors, an error inside an `||` chain would skip the check
+# instead of failing it, and a value past 2^63 wraps negative in the loop
+# counter and silently runs zero attempts.
 for setting in INDEX_ATTEMPTS CONNECT_TIMEOUT REQUEST_TIMEOUT; do
-  if [[ ! "${!setting}" =~ ^[1-9][0-9]*$ ]]; then
-    echo "${setting} must be an integer >= 1 (got '${!setting}')" >&2
+  if [[ ! "${!setting}" =~ ^[1-9][0-9]{0,4}$ ]]; then
+    echo "${setting} must be an integer from 1 to 99999 (got '${!setting}')" >&2
     exit 2
   fi
 done
-if [[ ! "$INDEX_SLEEP" =~ ^(0|[1-9][0-9]*)$ ]]; then
-  echo "INDEX_SLEEP must be an integer >= 0 (got '${INDEX_SLEEP}')" >&2
+if [[ ! "$INDEX_SLEEP" =~ ^(0|[1-9][0-9]{0,4})$ ]]; then
+  echo "INDEX_SLEEP must be an integer from 0 to 99999 (got '${INDEX_SLEEP}')" >&2
   exit 2
 fi
 

--- a/scripts/index-release.sh
+++ b/scripts/index-release.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Make a pushed release tag visible on pkg.go.dev.
+#
+# Neither the Go module proxy nor pkg.go.dev watches GitHub. The proxy fetches
+# a version the first time something asks for it, and pkg.go.dev indexes a
+# version when it is asked to (or, eventually, when its crawler gets to it).
+# Left alone, a tag can sit on GitHub for days while pkg.go.dev still shows the
+# previous release. This script performs the three requests that close that
+# gap, in order, and succeeds only once the version page actually renders:
+#
+#   1. GET  <proxy>/<escaped module>/@v/<version>.info   -> proxy fetches the tag
+#   2. POST <pkgsite>/fetch/<module>@<version>            -> pkg.go.dev indexes it
+#   3. GET  <pkgsite>/<module>@<version> until it is 200  -> the proof
+#
+# Usage: scripts/index-release.sh vX.Y.Z
+#
+# Environment (overridable, used by the tests to point at local stubs):
+#   GOPROXY_URL     default https://proxy.golang.org
+#   PKGSITE_URL     default https://pkg.go.dev
+#   INDEX_ATTEMPTS  how many times to poll the version page (default 30)
+#   INDEX_SLEEP     seconds between polls (default 10)
+#
+# Exit codes: 0 indexed; 1 a request failed (the URL and status are printed);
+# 2 bad usage.
+set -euo pipefail
+
+GOPROXY_URL="${GOPROXY_URL:-https://proxy.golang.org}"
+PKGSITE_URL="${PKGSITE_URL:-https://pkg.go.dev}"
+INDEX_ATTEMPTS="${INDEX_ATTEMPTS:-30}"
+INDEX_SLEEP="${INDEX_SLEEP:-10}"
+
+version="${1:-}"
+if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "usage: $0 vX.Y.Z (got '${version}')" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+go_mod="${script_dir}/../go.mod"
+module="$(awk '$1 == "module" { print $2; exit }' "$go_mod")"
+if [[ -z "$module" ]]; then
+  echo "could not read the module path from ${go_mod}" >&2
+  exit 1
+fi
+
+# The proxy's path encoding: every uppercase letter becomes '!' followed by
+# its lowercase form (github.com/ekoDB -> github.com/eko!db). Done one
+# character at a time because BSD sed has no case-conversion escape and the
+# macOS default bash predates ${var,,}.
+escape_module() {
+  local path="$1" out="" i c
+  for ((i = 0; i < ${#path}; i++)); do
+    c="${path:i:1}"
+    if [[ "$c" == [A-Z] ]]; then
+      # The proxy encodes ASCII A-Z only, so the locale classes would be wrong.
+      # shellcheck disable=SC2018,SC2019
+      out+="!$(printf '%s' "$c" | tr 'A-Z' 'a-z')"
+    else
+      out+="$c"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+# status <method> <url>: prints the HTTP status, or 000 when the request could
+# not be made at all, so a network failure is a distinct reading from a 404.
+status() {
+  local method="$1" url="$2"
+  curl -sS -o /dev/null -w '%{http_code}' -X "$method" "$url" 2>/dev/null || printf '000'
+}
+
+proxy_url="${GOPROXY_URL}/$(escape_module "$module")/@v/${version}.info"
+echo "1/3 asking the module proxy for ${module}@${version}"
+code="$(status GET "$proxy_url")"
+if [[ "$code" != "200" ]]; then
+  echo "proxy did not serve the version: ${proxy_url} -> HTTP ${code}" >&2
+  echo "is the tag pushed to origin, and does it point at a commit with a go.mod?" >&2
+  exit 1
+fi
+
+fetch_url="${PKGSITE_URL}/fetch/${module}@${version}"
+echo "2/3 asking pkg.go.dev to fetch ${module}@${version}"
+code="$(status POST "$fetch_url")"
+case "$code" in
+  200) ;;
+  404)
+    echo "pkg.go.dev could not find the version: ${fetch_url} -> HTTP ${code}" >&2
+    exit 1
+    ;;
+  *)
+    # pkg.go.dev answers with a 5xx while its worker is still processing the
+    # fetch; the page rendering below is the real success criterion.
+    echo "fetch request returned HTTP ${code}; polling the version page anyway"
+    ;;
+esac
+
+page_url="${PKGSITE_URL}/${module}@${version}"
+echo "3/3 waiting for ${page_url}"
+for ((attempt = 1; attempt <= INDEX_ATTEMPTS; attempt++)); do
+  code="$(status GET "$page_url")"
+  if [[ "$code" == "200" ]]; then
+    echo "indexed: ${page_url}"
+    exit 0
+  fi
+  echo "  attempt ${attempt}/${INDEX_ATTEMPTS}: HTTP ${code}"
+  if (( attempt < INDEX_ATTEMPTS )); then
+    sleep "$INDEX_SLEEP"
+  fi
+done
+echo "pkg.go.dev did not render the version after ${INDEX_ATTEMPTS} attempts: ${page_url} -> HTTP ${code}" >&2
+exit 1

--- a/scripts/index-release.sh
+++ b/scripts/index-release.sh
@@ -12,26 +12,43 @@
 #   2. POST <pkgsite>/fetch/<module>@<version>            -> pkg.go.dev indexes it
 #   3. GET  <pkgsite>/<module>@<version> until it is 200  -> the proof
 #
+# Steps 1 and 3 are polled, up to INDEX_ATTEMPTS times INDEX_SLEEP seconds
+# apart: step 1 because it runs seconds after the tag push and the proxy's
+# first fetch from origin is not instant, step 3 because pkg.go.dev processes
+# the fetch asynchronously. Every request carries a timeout, so a server that
+# accepts the connection and never answers cannot hang a release.
+#
 # Usage: scripts/index-release.sh vX.Y.Z
 #
 # Environment (overridable, used by the tests to point at local stubs):
 #   GOPROXY_URL     default https://proxy.golang.org
 #   PKGSITE_URL     default https://pkg.go.dev
-#   INDEX_ATTEMPTS  how many times to poll the version page (default 30)
-#   INDEX_SLEEP     seconds between polls (default 10)
+#   INDEX_ATTEMPTS  polls per polled step, an integer >= 1 (default 30)
+#   INDEX_SLEEP     seconds between polls, an integer >= 0 (default 10)
 #
-# Exit codes: 0 indexed; 1 a request failed (the URL and status are printed);
-# 2 bad usage.
+# Exit codes: 0 indexed; 1 a request failed (the URL and status are printed,
+# with curl's own message when the request could not be made at all); 2 bad
+# usage.
 set -euo pipefail
 
 GOPROXY_URL="${GOPROXY_URL:-https://proxy.golang.org}"
 PKGSITE_URL="${PKGSITE_URL:-https://pkg.go.dev}"
 INDEX_ATTEMPTS="${INDEX_ATTEMPTS:-30}"
 INDEX_SLEEP="${INDEX_SLEEP:-10}"
+CONNECT_TIMEOUT=10
+REQUEST_TIMEOUT=30
 
 version="${1:-}"
 if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "usage: $0 vX.Y.Z (got '${version}')" >&2
+  exit 2
+fi
+if [[ ! "$INDEX_ATTEMPTS" =~ ^[0-9]+$ ]] || (( INDEX_ATTEMPTS < 1 )); then
+  echo "INDEX_ATTEMPTS must be an integer >= 1 (got '${INDEX_ATTEMPTS}')" >&2
+  exit 2
+fi
+if [[ ! "$INDEX_SLEEP" =~ ^[0-9]+$ ]]; then
+  echo "INDEX_SLEEP must be an integer >= 0 (got '${INDEX_SLEEP}')" >&2
   exit 2
 fi
 
@@ -43,69 +60,110 @@ if [[ -z "$module" ]]; then
   exit 1
 fi
 
-# The proxy's path encoding: every uppercase letter becomes '!' followed by
-# its lowercase form (github.com/ekoDB -> github.com/eko!db). Done one
+# The proxy's path encoding: every uppercase ASCII letter becomes '!' followed
+# by its lowercase form (github.com/ekoDB -> github.com/eko!d!b). Done one
 # character at a time because BSD sed has no case-conversion escape and the
-# macOS default bash predates ${var,,}.
+# macOS default bash predates ${var,,}. The letters are listed rather than
+# written as a range so the match cannot depend on the locale's collation.
 escape_module() {
   local path="$1" out="" i c
   for ((i = 0; i < ${#path}; i++)); do
     c="${path:i:1}"
-    if [[ "$c" == [A-Z] ]]; then
-      # The proxy encodes ASCII A-Z only, so the locale classes would be wrong.
-      # shellcheck disable=SC2018,SC2019
-      out+="!$(printf '%s' "$c" | tr 'A-Z' 'a-z')"
-    else
-      out+="$c"
-    fi
+    case "$c" in
+      [ABCDEFGHIJKLMNOPQRSTUVWXYZ])
+        # The proxy encodes ASCII A-Z only, so the locale classes would be wrong.
+        # shellcheck disable=SC2018,SC2019
+        out+="!$(printf '%s' "$c" | tr 'A-Z' 'a-z')"
+        ;;
+      *) out+="$c" ;;
+    esac
   done
   printf '%s' "$out"
 }
 
-# status <method> <url>: prints the HTTP status, or 000 when the request could
-# not be made at all, so a network failure is a distinct reading from a 404.
-status() {
-  local method="$1" url="$2"
-  curl -sS -o /dev/null -w '%{http_code}' -X "$method" "$url" 2>/dev/null || printf '000'
+curl_stderr="$(mktemp)"
+trap 'rm -f "$curl_stderr"' EXIT
+
+# request <method> <url>: sets `code` to the HTTP status, or to 000 with
+# `detail` carrying curl's own message when no status was obtained (refused
+# connection, DNS failure, timeout). The two causes are kept apart so a network
+# failure never reads as a 404 and vice versa.
+code=""
+detail=""
+request() {
+  local method="$1" url="$2" out rc
+  detail=""
+  if out="$(curl -sS -o /dev/null -w '%{http_code}' \
+      --connect-timeout "$CONNECT_TIMEOUT" --max-time "$REQUEST_TIMEOUT" \
+      -X "$method" "$url" 2>"$curl_stderr")"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if (( rc != 0 )); then
+    code="000"
+    detail="$(tr -d '\n' <"$curl_stderr")"
+  else
+    code="$out"
+  fi
+}
+
+# describe: the status for a message, with curl's detail when there is one.
+describe() {
+  if [[ -n "$detail" ]]; then
+    printf 'HTTP %s (%s)' "$code" "$detail"
+  else
+    printf 'HTTP %s' "$code"
+  fi
+}
+
+# wait_for <method> <url>: polls until the status is 200, INDEX_ATTEMPTS times
+# INDEX_SLEEP seconds apart, with no sleep after the last attempt. Returns 0 on
+# a 200; otherwise returns 1 with `code`/`detail` holding the last reading.
+wait_for() {
+  local method="$1" url="$2" attempt
+  for ((attempt = 1; attempt <= INDEX_ATTEMPTS; attempt++)); do
+    request "$method" "$url"
+    if [[ "$code" == "200" ]]; then
+      return 0
+    fi
+    echo "  attempt ${attempt}/${INDEX_ATTEMPTS}: $(describe)"
+    if (( attempt < INDEX_ATTEMPTS )); then
+      sleep "$INDEX_SLEEP"
+    fi
+  done
+  return 1
 }
 
 proxy_url="${GOPROXY_URL}/$(escape_module "$module")/@v/${version}.info"
 echo "1/3 asking the module proxy for ${module}@${version}"
-code="$(status GET "$proxy_url")"
-if [[ "$code" != "200" ]]; then
-  echo "proxy did not serve the version: ${proxy_url} -> HTTP ${code}" >&2
+if ! wait_for GET "$proxy_url"; then
+  echo "proxy did not serve the version after ${INDEX_ATTEMPTS} attempts: ${proxy_url} -> $(describe)" >&2
   echo "is the tag pushed to origin, and does it point at a commit with a go.mod?" >&2
   exit 1
 fi
 
 fetch_url="${PKGSITE_URL}/fetch/${module}@${version}"
 echo "2/3 asking pkg.go.dev to fetch ${module}@${version}"
-code="$(status POST "$fetch_url")"
+request POST "$fetch_url"
 case "$code" in
   200) ;;
   404)
-    echo "pkg.go.dev could not find the version: ${fetch_url} -> HTTP ${code}" >&2
+    echo "pkg.go.dev could not find the version: ${fetch_url} -> $(describe)" >&2
     exit 1
     ;;
   *)
     # pkg.go.dev answers with a 5xx while its worker is still processing the
     # fetch; the page rendering below is the real success criterion.
-    echo "fetch request returned HTTP ${code}; polling the version page anyway"
+    echo "fetch request returned $(describe); polling the version page anyway"
     ;;
 esac
 
 page_url="${PKGSITE_URL}/${module}@${version}"
 echo "3/3 waiting for ${page_url}"
-for ((attempt = 1; attempt <= INDEX_ATTEMPTS; attempt++)); do
-  code="$(status GET "$page_url")"
-  if [[ "$code" == "200" ]]; then
-    echo "indexed: ${page_url}"
-    exit 0
-  fi
-  echo "  attempt ${attempt}/${INDEX_ATTEMPTS}: HTTP ${code}"
-  if (( attempt < INDEX_ATTEMPTS )); then
-    sleep "$INDEX_SLEEP"
-  fi
-done
-echo "pkg.go.dev did not render the version after ${INDEX_ATTEMPTS} attempts: ${page_url} -> HTTP ${code}" >&2
+if wait_for GET "$page_url"; then
+  echo "indexed: ${page_url}"
+  exit 0
+fi
+echo "pkg.go.dev did not render the version after ${INDEX_ATTEMPTS} attempts: ${page_url} -> $(describe)" >&2
 exit 1

--- a/scripts/index-release.sh
+++ b/scripts/index-release.sh
@@ -36,8 +36,7 @@
 #   REQUEST_TIMEOUT seconds for each whole request, 1 to 99999 (default 30)
 #
 # Exit codes: 0 indexed; 1 a request failed (the URL and status are printed,
-# with curl's own message when the request could not be made at all); 2 bad
-# usage.
+# with curl's own message when the request did not complete); 2 bad usage.
 set -euo pipefail
 
 GOPROXY_URL="${GOPROXY_URL:-https://proxy.golang.org}"

--- a/scripts/index_release_test.go
+++ b/scripts/index_release_test.go
@@ -7,14 +7,17 @@ package scripts_test
 
 import (
 	"bytes"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 const (
@@ -76,8 +79,24 @@ func (r *recorder) snapshot() []string {
 	return append([]string(nil), r.requests...)
 }
 
-// run executes the script with the two stub servers and a zero poll delay.
-func run(t *testing.T, proxy, site *httptest.Server, attempts string, args ...string) (int, string) {
+// stubs starts a proxy and a pkg.go.dev stand-in with the given status
+// scripts and returns their recorders and base URLs.
+func stubs(t *testing.T, proxyStatuses, siteStatuses map[string][]int) (*recorder, string, *recorder, string) {
+	t.Helper()
+	proxy, site := newRecorder(proxyStatuses), newRecorder(siteStatuses)
+	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
+	t.Cleanup(ps.Close)
+	t.Cleanup(ss.Close)
+	return proxy, ps.URL, site, ss.URL
+}
+
+// polling is the script's poll configuration, as the strings it reads.
+type polling struct{ attempts, sleep string }
+
+func fast(attempts string) polling { return polling{attempts: attempts, sleep: "0"} }
+
+// run executes the script against the two base URLs.
+func run(t *testing.T, proxyURL, siteURL string, p polling, args ...string) (int, string) {
 	t.Helper()
 	script, err := filepath.Abs("index-release.sh")
 	if err != nil {
@@ -85,10 +104,10 @@ func run(t *testing.T, proxy, site *httptest.Server, attempts string, args ...st
 	}
 	cmd := exec.Command("bash", append([]string{script}, args...)...)
 	cmd.Env = append(os.Environ(),
-		"GOPROXY_URL="+proxy.URL,
-		"PKGSITE_URL="+site.URL,
-		"INDEX_ATTEMPTS="+attempts,
-		"INDEX_SLEEP=0",
+		"GOPROXY_URL="+proxyURL,
+		"PKGSITE_URL="+siteURL,
+		"INDEX_ATTEMPTS="+p.attempts,
+		"INDEX_SLEEP="+p.sleep,
 	)
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -103,14 +122,24 @@ func run(t *testing.T, proxy, site *httptest.Server, attempts string, args ...st
 	return code, out.String()
 }
 
-func TestIndexRelease_SuccessRequestsProxyThenFetchThenPage(t *testing.T) {
-	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
-	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {200}})
-	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
-	defer ps.Close()
-	defer ss.Close()
+// closedPort returns a loopback URL nothing is listening on.
+func closedPort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return "http://" + addr
+}
 
-	code, out := run(t, ps, ss, "3", version)
+func TestIndexRelease_SuccessRequestsProxyThenFetchThenPage(t *testing.T) {
+	proxy, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {200}, pagePath: {200}})
+
+	code, out := run(t, proxyURL, siteURL, fast("3"), version)
 	if code != 0 {
 		t.Fatalf("expected exit 0, got %d:\n%s", code, out)
 	}
@@ -120,19 +149,17 @@ func TestIndexRelease_SuccessRequestsProxyThenFetchThenPage(t *testing.T) {
 	if got := site.snapshot(); len(got) != 2 || got[0] != "POST "+fetchPath || got[1] != "GET "+pagePath {
 		t.Fatalf("pkg.go.dev requests = %v, want POST fetch then GET page", got)
 	}
-	if !strings.Contains(out, ss.URL+pagePath) {
+	if !strings.Contains(out, siteURL+pagePath) {
 		t.Fatalf("success output should name the version page, got:\n%s", out)
 	}
 }
 
 func TestIndexRelease_PollsPageUntilItRenders(t *testing.T) {
-	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
-	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {404, 404, 200}})
-	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
-	defer ps.Close()
-	defer ss.Close()
+	_, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {200}, pagePath: {404, 404, 200}})
 
-	code, out := run(t, ps, ss, "5", version)
+	code, out := run(t, proxyURL, siteURL, fast("5"), version)
 	if code != 0 {
 		t.Fatalf("expected exit 0 once the page renders, got %d:\n%s", code, out)
 	}
@@ -141,18 +168,38 @@ func TestIndexRelease_PollsPageUntilItRenders(t *testing.T) {
 	}
 }
 
-func TestIndexRelease_ProxyMissFailsBeforeTouchingPkgsite(t *testing.T) {
-	proxy := newRecorder(map[string][]int{proxyInfoPath: {404}})
-	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {200}})
-	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
-	defer ps.Close()
-	defer ss.Close()
+func TestIndexRelease_PollsProxyUntilItServesTheVersion(t *testing.T) {
+	// Seconds after a tag push the proxy's first fetch from origin may not
+	// have completed; the proxy step retries within the same budget.
+	proxy, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {404, 200}},
+		map[string][]int{fetchPath: {200}, pagePath: {200}})
 
-	code, out := run(t, ps, ss, "3", version)
+	code, out := run(t, proxyURL, siteURL, fast("3"), version)
+	if code != 0 {
+		t.Fatalf("expected exit 0 once the proxy serves the version, got %d:\n%s", code, out)
+	}
+	if n := proxy.count("GET " + proxyInfoPath); n != 2 {
+		t.Fatalf("proxy polled %d times, want 2 (a 404 then a 200)", n)
+	}
+	if got := site.snapshot(); len(got) != 2 {
+		t.Fatalf("pkg.go.dev requests = %v, want fetch then page after the proxy succeeded", got)
+	}
+}
+
+func TestIndexRelease_ProxyMissFailsBeforeTouchingPkgsite(t *testing.T) {
+	proxy, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {404}},
+		map[string][]int{fetchPath: {200}, pagePath: {200}})
+
+	code, out := run(t, proxyURL, siteURL, fast("3"), version)
 	if code != 1 {
 		t.Fatalf("expected exit 1 on a proxy 404, got %d:\n%s", code, out)
 	}
-	if !strings.Contains(out, ps.URL+proxyInfoPath) || !strings.Contains(out, "404") {
+	if n := proxy.count("GET " + proxyInfoPath); n != 3 {
+		t.Fatalf("proxy polled %d times, want exactly INDEX_ATTEMPTS=3", n)
+	}
+	if !strings.Contains(out, proxyURL+proxyInfoPath) || !strings.Contains(out, "HTTP 404") {
 		t.Fatalf("failure output must name the proxy URL and status, got:\n%s", out)
 	}
 	if got := site.snapshot(); len(got) != 0 {
@@ -160,18 +207,37 @@ func TestIndexRelease_ProxyMissFailsBeforeTouchingPkgsite(t *testing.T) {
 	}
 }
 
-func TestIndexRelease_FetchNotFoundFailsWithoutPolling(t *testing.T) {
-	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
-	site := newRecorder(map[string][]int{fetchPath: {404}, pagePath: {200}})
-	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
-	defer ps.Close()
-	defer ss.Close()
+func TestIndexRelease_ConnectionFailureReportsCurlDetailOnce(t *testing.T) {
+	// No status at all is a different reading from a 404: the output carries a
+	// single 000 and curl's own message, never a doubled "000000".
+	_, siteURL := newRecorder(nil), closedPort(t)
+	proxyURL := closedPort(t)
 
-	code, out := run(t, ps, ss, "3", version)
+	code, out := run(t, proxyURL, siteURL, fast("2"), version)
+	if code != 1 {
+		t.Fatalf("expected exit 1 when the proxy cannot be reached, got %d:\n%s", code, out)
+	}
+	if strings.Contains(out, "000000") {
+		t.Fatalf("status must not be doubled on a connection failure, got:\n%s", out)
+	}
+	if !regexp.MustCompile(`HTTP 000 \(curl: \(\d+\) `).MatchString(out) {
+		t.Fatalf("connection failure must print HTTP 000 with curl's message, got:\n%s", out)
+	}
+	if !strings.Contains(out, proxyURL+proxyInfoPath) {
+		t.Fatalf("failure output must name the proxy URL, got:\n%s", out)
+	}
+}
+
+func TestIndexRelease_FetchNotFoundFailsWithoutPolling(t *testing.T) {
+	_, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {404}, pagePath: {200}})
+
+	code, out := run(t, proxyURL, siteURL, fast("3"), version)
 	if code != 1 {
 		t.Fatalf("expected exit 1 on a fetch 404, got %d:\n%s", code, out)
 	}
-	if !strings.Contains(out, ss.URL+fetchPath) || !strings.Contains(out, "404") {
+	if !strings.Contains(out, siteURL+fetchPath) || !strings.Contains(out, "HTTP 404") {
 		t.Fatalf("failure output must name the fetch URL and status, got:\n%s", out)
 	}
 	if n := site.count("GET " + pagePath); n != 0 {
@@ -183,13 +249,11 @@ func TestIndexRelease_FetchTransientFailureStillPolls(t *testing.T) {
 	// pkg.go.dev answers the fetch endpoint with a 5xx while its worker is
 	// still processing; the page rendering is the success criterion, so the
 	// script keeps polling rather than giving up on that code.
-	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
-	site := newRecorder(map[string][]int{fetchPath: {500}, pagePath: {404, 200}})
-	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
-	defer ps.Close()
-	defer ss.Close()
+	_, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {500}, pagePath: {404, 200}})
 
-	code, out := run(t, ps, ss, "3", version)
+	code, out := run(t, proxyURL, siteURL, fast("3"), version)
 	if code != 0 {
 		t.Fatalf("expected exit 0 when the page renders after a transient fetch error, got %d:\n%s", code, out)
 	}
@@ -199,37 +263,57 @@ func TestIndexRelease_FetchTransientFailureStillPolls(t *testing.T) {
 }
 
 func TestIndexRelease_PollTimeoutFailsNamingThePage(t *testing.T) {
-	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
-	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {404}})
-	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
-	defer ps.Close()
-	defer ss.Close()
+	_, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {200}, pagePath: {404}})
 
-	code, out := run(t, ps, ss, "3", version)
+	code, out := run(t, proxyURL, siteURL, fast("3"), version)
 	if code != 1 {
 		t.Fatalf("expected exit 1 when the page never renders, got %d:\n%s", code, out)
 	}
 	if n := site.count("GET " + pagePath); n != 3 {
 		t.Fatalf("page polled %d times, want exactly INDEX_ATTEMPTS=3", n)
 	}
-	if !strings.Contains(out, ss.URL+pagePath) || !strings.Contains(out, "404") {
+	if !strings.Contains(out, siteURL+pagePath) || !strings.Contains(out, "HTTP 404") {
 		t.Fatalf("timeout output must name the page URL and last status, got:\n%s", out)
 	}
 }
 
+func TestIndexRelease_SleepsBetweenAttemptsButNotAfterTheLast(t *testing.T) {
+	_, proxyURL, _, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {200}, pagePath: {404}})
+
+	start := time.Now()
+	code, out := run(t, proxyURL, siteURL, polling{attempts: "2", sleep: "1"}, version)
+	if code != 1 {
+		t.Fatalf("expected exit 1, got %d:\n%s", code, out)
+	}
+	if elapsed := time.Since(start); elapsed < time.Second {
+		t.Fatalf("two attempts with INDEX_SLEEP=1 took %v, want at least one second of sleep between them", elapsed)
+	}
+
+	start = time.Now()
+	code, out = run(t, proxyURL, siteURL, polling{attempts: "1", sleep: "1"}, version)
+	if code != 1 {
+		t.Fatalf("expected exit 1, got %d:\n%s", code, out)
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("a single attempt with INDEX_SLEEP=1 took %v, want no sleep after the last attempt", elapsed)
+	}
+}
+
 func TestIndexRelease_RejectsMalformedVersionBeforeAnyRequest(t *testing.T) {
-	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
-	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {200}})
-	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
-	defer ps.Close()
-	defer ss.Close()
+	proxy, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {200}, pagePath: {200}})
 
 	for _, bad := range []string{"", "1.2.3", "v1.2", "v1.2.3-rc.1"} {
 		args := []string{bad}
 		if bad == "" {
 			args = nil
 		}
-		code, out := run(t, ps, ss, "3", args...)
+		code, out := run(t, proxyURL, siteURL, fast("3"), args...)
 		if code != 2 {
 			t.Errorf("version %q: expected exit 2, got %d:\n%s", bad, code, out)
 		}
@@ -239,5 +323,30 @@ func TestIndexRelease_RejectsMalformedVersionBeforeAnyRequest(t *testing.T) {
 	}
 	if got := site.snapshot(); len(got) != 0 {
 		t.Fatalf("pkg.go.dev must not be contacted for a malformed version, got %v", got)
+	}
+}
+
+func TestIndexRelease_RejectsInvalidPollingBeforeAnyRequest(t *testing.T) {
+	proxy, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {200}, pagePath: {200}})
+
+	for _, p := range []polling{
+		{attempts: "0", sleep: "0"},
+		{attempts: "abc", sleep: "0"},
+		{attempts: "-1", sleep: "0"},
+		{attempts: "3", sleep: "x"},
+		{attempts: "3", sleep: "-1"},
+	} {
+		code, out := run(t, proxyURL, siteURL, p, version)
+		if code != 2 {
+			t.Errorf("INDEX_ATTEMPTS=%q INDEX_SLEEP=%q: expected exit 2, got %d:\n%s", p.attempts, p.sleep, code, out)
+		}
+	}
+	if got := proxy.snapshot(); len(got) != 0 {
+		t.Fatalf("proxy must not be contacted with invalid polling values, got %v", got)
+	}
+	if got := site.snapshot(); len(got) != 0 {
+		t.Fatalf("pkg.go.dev must not be contacted with invalid polling values, got %v", got)
 	}
 }

--- a/scripts/index_release_test.go
+++ b/scripts/index_release_test.go
@@ -8,7 +8,6 @@ package scripts_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -147,20 +146,29 @@ func runScript(t *testing.T, script, proxyURL, siteURL string, p polling, args .
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
+	start := time.Now()
 	err := cmd.Run()
-	if ctx.Err() != nil {
-		t.Fatalf("script did not finish within %v:\n%s", runDeadline, out.String())
-	}
 	code := 0
 	if exitErr, ok := err.(*exec.ExitError); ok {
 		code = exitErr.ExitCode()
+		// A process ended by a signal reports -1; with the deadline passed
+		// that is the runner's kill, and only that combination is a timeout,
+		// so a run that exited on its own just before the deadline keeps its
+		// real exit code.
+		if code == -1 && ctx.Err() != nil {
+			t.Fatalf("script did not finish within %v (killed after %v):\n%s", runDeadline, time.Since(start), out.String())
+		}
 	} else if err != nil {
 		t.Fatalf("running script: %v", err)
 	}
 	return code, out.String()
 }
 
-// closedPort returns a loopback URL nothing is listening on.
+// closedPort returns a loopback URL nothing is listening on. It relies on the
+// kernel not handing the just-released ephemeral port to another listener
+// started by this process during the test; if that ever happened the run
+// would see an HTTP status instead of a refused connection and the calling
+// test would fail, never pass, so a flake here is loud rather than silent.
 func closedPort(t *testing.T) string {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -441,8 +449,14 @@ func TestIndexRelease_RejectsInvalidPollingBeforeAnyRequest(t *testing.T) {
 		{attempts: "3", sleep: "x"},
 		{attempts: "3", sleep: "-1"},
 		{attempts: "3", sleep: "08"},
+		// past five digits: 2^63 wrapped the loop counter negative and ran
+		// zero attempts while claiming otherwise
+		{attempts: "100000", sleep: "0"},
+		{attempts: "9223372036854775808", sleep: "0"},
+		{attempts: "3", sleep: "100000"},
 		{attempts: "3", sleep: "0", timeout: "0"},
 		{attempts: "3", sleep: "0", timeout: "abc"},
+		{attempts: "3", sleep: "0", timeout: "100000"},
 	} {
 		code, out := run(t, proxyURL, siteURL, p, version)
 		if code != 2 {
@@ -524,7 +538,9 @@ func TestIndexRelease_MissingOrIncompleteGoModFailsBeforeAnyRequest(t *testing.T
 		if !strings.Contains(out, "could not read the module path from") {
 			t.Errorf("%s go.mod: expected the script's own message, got:\n%s", name, out)
 		}
-		if strings.Contains(out, fmt.Sprintf("awk: can't open")) {
+		// awk's own diagnostics differ between BSD and GNU/mawk in wording
+		// but all carry the "awk:" prefix, so that is what must be absent.
+		if strings.Contains(out, "awk:") {
 			t.Errorf("%s go.mod: awk's error must not reach the operator, got:\n%s", name, out)
 		}
 	}

--- a/scripts/index_release_test.go
+++ b/scripts/index_release_test.go
@@ -589,6 +589,11 @@ func TestIndexRelease_StalledTransferIsNotARender(t *testing.T) {
 	if !regexp.MustCompile(`attempt 1/1: HTTP 000 \(curl: \(28\) `).MatchString(out) {
 		t.Fatalf("a stalled transfer must be reported as curl's timeout with no status, got:\n%s", out)
 	}
+	// curl's message names the partial body it received, which is what
+	// distinguishes headers-then-stall from a server that never answered.
+	if !strings.Contains(out, "out of 100 bytes") {
+		t.Fatalf("the stand-in must have delivered headers and part of the body before stalling, got:\n%s", out)
+	}
 	if strings.Contains(out, "HTTP 200") {
 		t.Fatalf("a partial 200 must not be reported as a status, got:\n%s", out)
 	}

--- a/scripts/index_release_test.go
+++ b/scripts/index_release_test.go
@@ -1,0 +1,243 @@
+package scripts_test
+
+// Drives scripts/index-release.sh against local stand-ins for the Go module
+// proxy and pkg.go.dev, so the release step that makes a pushed tag visible on
+// pkg.go.dev is proven in both directions: it exits 0 only once the version
+// page renders, and it names the failing URL and status when a step does not.
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const (
+	module        = "github.com/ekoDB/ekodb-client-go"
+	escapedModule = "github.com/eko!d!b/ekodb-client-go"
+	version       = "v1.2.3"
+	proxyInfoPath = "/" + escapedModule + "/@v/" + version + ".info"
+	fetchPath     = "/fetch/" + module + "@" + version
+	pagePath      = "/" + module + "@" + version
+)
+
+// recorder is an httptest handler that remembers every request it served and
+// answers each path with a scripted sequence of status codes (the last code
+// repeats once the sequence is exhausted).
+type recorder struct {
+	mu       sync.Mutex
+	requests []string // "METHOD path"
+	statuses map[string][]int
+	served   map[string]int
+}
+
+func newRecorder(statuses map[string][]int) *recorder {
+	return &recorder{statuses: statuses, served: map[string]int{}}
+}
+
+func (r *recorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, req.Method+" "+req.URL.Path)
+	seq, ok := r.statuses[req.URL.Path]
+	if !ok {
+		http.NotFound(w, req)
+		return
+	}
+	i := r.served[req.URL.Path]
+	if i >= len(seq) {
+		i = len(seq) - 1
+	}
+	r.served[req.URL.Path]++
+	w.WriteHeader(seq[i])
+	_, _ = w.Write([]byte(http.StatusText(seq[i])))
+}
+
+func (r *recorder) count(prefix string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, req := range r.requests {
+		if strings.HasPrefix(req, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+func (r *recorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.requests...)
+}
+
+// run executes the script with the two stub servers and a zero poll delay.
+func run(t *testing.T, proxy, site *httptest.Server, attempts string, args ...string) (int, string) {
+	t.Helper()
+	script, err := filepath.Abs("index-release.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("bash", append([]string{script}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GOPROXY_URL="+proxy.URL,
+		"PKGSITE_URL="+site.URL,
+		"INDEX_ATTEMPTS="+attempts,
+		"INDEX_SLEEP=0",
+	)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err = cmd.Run()
+	code := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		code = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("running script: %v", err)
+	}
+	return code, out.String()
+}
+
+func TestIndexRelease_SuccessRequestsProxyThenFetchThenPage(t *testing.T) {
+	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
+	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {200}})
+	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
+	defer ps.Close()
+	defer ss.Close()
+
+	code, out := run(t, ps, ss, "3", version)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d:\n%s", code, out)
+	}
+	if got := proxy.snapshot(); len(got) != 1 || got[0] != "GET "+proxyInfoPath {
+		t.Fatalf("proxy requests = %v, want exactly one GET of the escaped .info path", got)
+	}
+	if got := site.snapshot(); len(got) != 2 || got[0] != "POST "+fetchPath || got[1] != "GET "+pagePath {
+		t.Fatalf("pkg.go.dev requests = %v, want POST fetch then GET page", got)
+	}
+	if !strings.Contains(out, ss.URL+pagePath) {
+		t.Fatalf("success output should name the version page, got:\n%s", out)
+	}
+}
+
+func TestIndexRelease_PollsPageUntilItRenders(t *testing.T) {
+	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
+	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {404, 404, 200}})
+	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
+	defer ps.Close()
+	defer ss.Close()
+
+	code, out := run(t, ps, ss, "5", version)
+	if code != 0 {
+		t.Fatalf("expected exit 0 once the page renders, got %d:\n%s", code, out)
+	}
+	if n := site.count("GET " + pagePath); n != 3 {
+		t.Fatalf("page polled %d times, want 3 (two 404s then a 200)", n)
+	}
+}
+
+func TestIndexRelease_ProxyMissFailsBeforeTouchingPkgsite(t *testing.T) {
+	proxy := newRecorder(map[string][]int{proxyInfoPath: {404}})
+	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {200}})
+	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
+	defer ps.Close()
+	defer ss.Close()
+
+	code, out := run(t, ps, ss, "3", version)
+	if code != 1 {
+		t.Fatalf("expected exit 1 on a proxy 404, got %d:\n%s", code, out)
+	}
+	if !strings.Contains(out, ps.URL+proxyInfoPath) || !strings.Contains(out, "404") {
+		t.Fatalf("failure output must name the proxy URL and status, got:\n%s", out)
+	}
+	if got := site.snapshot(); len(got) != 0 {
+		t.Fatalf("pkg.go.dev must not be contacted after a proxy miss, got %v", got)
+	}
+}
+
+func TestIndexRelease_FetchNotFoundFailsWithoutPolling(t *testing.T) {
+	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
+	site := newRecorder(map[string][]int{fetchPath: {404}, pagePath: {200}})
+	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
+	defer ps.Close()
+	defer ss.Close()
+
+	code, out := run(t, ps, ss, "3", version)
+	if code != 1 {
+		t.Fatalf("expected exit 1 on a fetch 404, got %d:\n%s", code, out)
+	}
+	if !strings.Contains(out, ss.URL+fetchPath) || !strings.Contains(out, "404") {
+		t.Fatalf("failure output must name the fetch URL and status, got:\n%s", out)
+	}
+	if n := site.count("GET " + pagePath); n != 0 {
+		t.Fatalf("page must not be polled after fetch reports not found, polled %d times", n)
+	}
+}
+
+func TestIndexRelease_FetchTransientFailureStillPolls(t *testing.T) {
+	// pkg.go.dev answers the fetch endpoint with a 5xx while its worker is
+	// still processing; the page rendering is the success criterion, so the
+	// script keeps polling rather than giving up on that code.
+	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
+	site := newRecorder(map[string][]int{fetchPath: {500}, pagePath: {404, 200}})
+	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
+	defer ps.Close()
+	defer ss.Close()
+
+	code, out := run(t, ps, ss, "3", version)
+	if code != 0 {
+		t.Fatalf("expected exit 0 when the page renders after a transient fetch error, got %d:\n%s", code, out)
+	}
+	if n := site.count("GET " + pagePath); n != 2 {
+		t.Fatalf("page polled %d times, want 2", n)
+	}
+}
+
+func TestIndexRelease_PollTimeoutFailsNamingThePage(t *testing.T) {
+	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
+	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {404}})
+	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
+	defer ps.Close()
+	defer ss.Close()
+
+	code, out := run(t, ps, ss, "3", version)
+	if code != 1 {
+		t.Fatalf("expected exit 1 when the page never renders, got %d:\n%s", code, out)
+	}
+	if n := site.count("GET " + pagePath); n != 3 {
+		t.Fatalf("page polled %d times, want exactly INDEX_ATTEMPTS=3", n)
+	}
+	if !strings.Contains(out, ss.URL+pagePath) || !strings.Contains(out, "404") {
+		t.Fatalf("timeout output must name the page URL and last status, got:\n%s", out)
+	}
+}
+
+func TestIndexRelease_RejectsMalformedVersionBeforeAnyRequest(t *testing.T) {
+	proxy := newRecorder(map[string][]int{proxyInfoPath: {200}})
+	site := newRecorder(map[string][]int{fetchPath: {200}, pagePath: {200}})
+	ps, ss := httptest.NewServer(proxy), httptest.NewServer(site)
+	defer ps.Close()
+	defer ss.Close()
+
+	for _, bad := range []string{"", "1.2.3", "v1.2", "v1.2.3-rc.1"} {
+		args := []string{bad}
+		if bad == "" {
+			args = nil
+		}
+		code, out := run(t, ps, ss, "3", args...)
+		if code != 2 {
+			t.Errorf("version %q: expected exit 2, got %d:\n%s", bad, code, out)
+		}
+	}
+	if got := proxy.snapshot(); len(got) != 0 {
+		t.Fatalf("proxy must not be contacted for a malformed version, got %v", got)
+	}
+	if got := site.snapshot(); len(got) != 0 {
+		t.Fatalf("pkg.go.dev must not be contacted for a malformed version, got %v", got)
+	}
+}

--- a/scripts/index_release_test.go
+++ b/scripts/index_release_test.go
@@ -7,6 +7,8 @@ package scripts_test
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -29,9 +31,14 @@ const (
 	pagePath      = "/" + module + "@" + version
 )
 
+// hangFor is how long a scripted status of 0 makes the recorder hold a request
+// before answering; longer than any REQUEST_TIMEOUT the tests set, so curl
+// gives up first and reports its own timeout.
+const hangFor = 2 * time.Second
+
 // recorder is an httptest handler that remembers every request it served and
 // answers each path with a scripted sequence of status codes (the last code
-// repeats once the sequence is exhausted).
+// repeats once the sequence is exhausted; a 0 holds the request for hangFor).
 type recorder struct {
 	mu       sync.Mutex
 	requests []string // "METHOD path"
@@ -57,8 +64,15 @@ func (r *recorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		i = len(seq) - 1
 	}
 	r.served[req.URL.Path]++
-	w.WriteHeader(seq[i])
-	_, _ = w.Write([]byte(http.StatusText(seq[i])))
+	status := seq[i]
+	if status == 0 {
+		r.mu.Unlock()
+		time.Sleep(hangFor)
+		r.mu.Lock()
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(http.StatusText(status)))
 }
 
 func (r *recorder) count(prefix string) int {
@@ -90,29 +104,53 @@ func stubs(t *testing.T, proxyStatuses, siteStatuses map[string][]int) (*recorde
 	return proxy, ps.URL, site, ss.URL
 }
 
-// polling is the script's poll configuration, as the strings it reads.
-type polling struct{ attempts, sleep string }
+// polling is the script's poll and timeout configuration, as the strings it
+// reads; an empty timeout leaves the script's defaults in place.
+type polling struct{ attempts, sleep, timeout string }
 
 func fast(attempts string) polling { return polling{attempts: attempts, sleep: "0"} }
 
-// run executes the script against the two base URLs.
+// run executes the repository's script against the two base URLs.
 func run(t *testing.T, proxyURL, siteURL string, p polling, args ...string) (int, string) {
 	t.Helper()
 	script, err := filepath.Abs("index-release.sh")
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("bash", append([]string{script}, args...)...)
+	return runScript(t, script, proxyURL, siteURL, p, args...)
+}
+
+// runDeadline bounds every script run: a script that hangs (a request with
+// no timeout against a server that never answers) fails the test here rather
+// than stalling the package until go test gives up.
+const runDeadline = 20 * time.Second
+
+// runScript executes the script at the given path against the two base URLs.
+func runScript(t *testing.T, script, proxyURL, siteURL string, p polling, args ...string) (int, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), runDeadline)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", append([]string{script}, args...)...)
+	// On the deadline the parent bash is killed, but a command substitution
+	// still running a request holds the inherited pipes; WaitDelay closes
+	// them so the run returns instead of waiting on that orphan.
+	cmd.WaitDelay = 2 * time.Second
 	cmd.Env = append(os.Environ(),
 		"GOPROXY_URL="+proxyURL,
 		"PKGSITE_URL="+siteURL,
 		"INDEX_ATTEMPTS="+p.attempts,
 		"INDEX_SLEEP="+p.sleep,
 	)
+	if p.timeout != "" {
+		cmd.Env = append(cmd.Env, "CONNECT_TIMEOUT="+p.timeout, "REQUEST_TIMEOUT="+p.timeout)
+	}
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	err = cmd.Run()
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		t.Fatalf("script did not finish within %v:\n%s", runDeadline, out.String())
+	}
 	code := 0
 	if exitErr, ok := err.(*exec.ExitError); ok {
 		code = exitErr.ExitCode()
@@ -132,6 +170,64 @@ func closedPort(t *testing.T) string {
 	addr := l.Addr().String()
 	_ = l.Close()
 	return "http://" + addr
+}
+
+// blackHole returns a URL whose server accepts every connection and never
+// answers, so only a client-side timeout can end a request to it.
+func blackHole(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var conns []net.Conn
+	var mu sync.Mutex
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			conns = append(conns, c)
+			mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = l.Close()
+		mu.Lock()
+		defer mu.Unlock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	})
+	return "http://" + l.Addr().String()
+}
+
+// scriptBeside copies the script into a fresh directory whose parent holds
+// the given go.mod content (none when goMod is nil), so the module lookup can
+// be driven against a missing or incomplete file.
+func scriptBeside(t *testing.T, goMod []byte) string {
+	t.Helper()
+	src, err := os.ReadFile("index-release.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	dir := filepath.Join(root, "scripts")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(dir, "index-release.sh")
+	if err := os.WriteFile(script, src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if goMod != nil {
+		if err := os.WriteFile(filepath.Join(root, "go.mod"), goMod, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return script
 }
 
 func TestIndexRelease_SuccessRequestsProxyThenFetchThenPage(t *testing.T) {
@@ -210,8 +306,7 @@ func TestIndexRelease_ProxyMissFailsBeforeTouchingPkgsite(t *testing.T) {
 func TestIndexRelease_ConnectionFailureReportsCurlDetailOnce(t *testing.T) {
 	// No status at all is a different reading from a 404: the output carries a
 	// single 000 and curl's own message, never a doubled "000000".
-	_, siteURL := newRecorder(nil), closedPort(t)
-	proxyURL := closedPort(t)
+	proxyURL, siteURL := closedPort(t), closedPort(t)
 
 	code, out := run(t, proxyURL, siteURL, fast("2"), version)
 	if code != 1 {
@@ -284,22 +379,26 @@ func TestIndexRelease_SleepsBetweenAttemptsButNotAfterTheLast(t *testing.T) {
 		map[string][]int{proxyInfoPath: {200}},
 		map[string][]int{fetchPath: {200}, pagePath: {404}})
 
+	// The sleep is long relative to a run that makes no sleep at all (tens of
+	// milliseconds), so the upper bound below has a wide margin on a loaded
+	// runner while still failing if the last attempt were followed by a sleep.
+	const sleep = 2 * time.Second
 	start := time.Now()
-	code, out := run(t, proxyURL, siteURL, polling{attempts: "2", sleep: "1"}, version)
+	code, out := run(t, proxyURL, siteURL, polling{attempts: "2", sleep: "2"}, version)
 	if code != 1 {
 		t.Fatalf("expected exit 1, got %d:\n%s", code, out)
 	}
-	if elapsed := time.Since(start); elapsed < time.Second {
-		t.Fatalf("two attempts with INDEX_SLEEP=1 took %v, want at least one second of sleep between them", elapsed)
+	if elapsed := time.Since(start); elapsed < sleep {
+		t.Fatalf("two attempts with INDEX_SLEEP=2 took %v, want at least one sleep between them", elapsed)
 	}
 
 	start = time.Now()
-	code, out = run(t, proxyURL, siteURL, polling{attempts: "1", sleep: "1"}, version)
+	code, out = run(t, proxyURL, siteURL, polling{attempts: "1", sleep: "2"}, version)
 	if code != 1 {
 		t.Fatalf("expected exit 1, got %d:\n%s", code, out)
 	}
-	if elapsed := time.Since(start); elapsed >= time.Second {
-		t.Fatalf("a single attempt with INDEX_SLEEP=1 took %v, want no sleep after the last attempt", elapsed)
+	if elapsed := time.Since(start); elapsed >= sleep {
+		t.Fatalf("a single attempt with INDEX_SLEEP=2 took %v, want no sleep after the last attempt", elapsed)
 	}
 }
 
@@ -335,12 +434,22 @@ func TestIndexRelease_RejectsInvalidPollingBeforeAnyRequest(t *testing.T) {
 		{attempts: "0", sleep: "0"},
 		{attempts: "abc", sleep: "0"},
 		{attempts: "-1", sleep: "0"},
+		// leading zeros: bash would read these as octal inside (( )) and
+		// error, which must be a rejection rather than a skipped check
+		{attempts: "08", sleep: "0"},
+		{attempts: "007", sleep: "0"},
 		{attempts: "3", sleep: "x"},
 		{attempts: "3", sleep: "-1"},
+		{attempts: "3", sleep: "08"},
+		{attempts: "3", sleep: "0", timeout: "0"},
+		{attempts: "3", sleep: "0", timeout: "abc"},
 	} {
 		code, out := run(t, proxyURL, siteURL, p, version)
 		if code != 2 {
-			t.Errorf("INDEX_ATTEMPTS=%q INDEX_SLEEP=%q: expected exit 2, got %d:\n%s", p.attempts, p.sleep, code, out)
+			t.Errorf("INDEX_ATTEMPTS=%q INDEX_SLEEP=%q timeout=%q: expected exit 2, got %d:\n%s", p.attempts, p.sleep, p.timeout, code, out)
+		}
+		if !strings.Contains(out, "must be an integer") {
+			t.Errorf("INDEX_ATTEMPTS=%q INDEX_SLEEP=%q timeout=%q: expected the script's own message, got:\n%s", p.attempts, p.sleep, p.timeout, out)
 		}
 	}
 	if got := proxy.snapshot(); len(got) != 0 {
@@ -348,5 +457,81 @@ func TestIndexRelease_RejectsInvalidPollingBeforeAnyRequest(t *testing.T) {
 	}
 	if got := site.snapshot(); len(got) != 0 {
 		t.Fatalf("pkg.go.dev must not be contacted with invalid polling values, got %v", got)
+	}
+}
+
+func TestIndexRelease_UnresponsiveServerEndsAtTheRequestTimeout(t *testing.T) {
+	// A server that accepts the connection and never answers can only be
+	// ended by the client-side timeout; with the timeouts at one second the
+	// run must finish far sooner than the 30-second default would allow.
+	proxyURL := blackHole(t)
+	siteURL := closedPort(t)
+
+	start := time.Now()
+	code, out := run(t, proxyURL, siteURL, polling{attempts: "1", sleep: "0", timeout: "1"}, version)
+	elapsed := time.Since(start)
+	if code != 1 {
+		t.Fatalf("expected exit 1 when the proxy never answers, got %d:\n%s", code, out)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("run against an unresponsive server took %v, want it bounded by the one-second timeout", elapsed)
+	}
+	if !regexp.MustCompile(`HTTP 000 \(curl: \(28\) `).MatchString(out) {
+		t.Fatalf("an unresponsive server must be reported as curl's timeout (28), got:\n%s", out)
+	}
+}
+
+func TestIndexRelease_LaterAttemptDoesNotCarryAnEarlierRequestsDetail(t *testing.T) {
+	// The proxy hangs on the first attempt (curl times out), answers 404 on
+	// the second and 200 on the third. The 404 line must carry no trace of
+	// the earlier timeout message, and the run must then succeed.
+	proxy, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {0, 404, 200}},
+		map[string][]int{fetchPath: {200}, pagePath: {200}})
+
+	code, out := run(t, proxyURL, siteURL, polling{attempts: "3", sleep: "0", timeout: "1"}, version)
+	if code != 0 {
+		t.Fatalf("expected exit 0 once the proxy answers, got %d:\n%s", code, out)
+	}
+	if n := proxy.count("GET " + proxyInfoPath); n != 3 {
+		t.Fatalf("proxy polled %d times, want 3", n)
+	}
+	if !regexp.MustCompile(`attempt 1/3: HTTP 000 \(curl: \(28\) `).MatchString(out) {
+		t.Fatalf("first attempt must report curl's timeout, got:\n%s", out)
+	}
+	if !strings.Contains(out, "attempt 2/3: HTTP 404\n") {
+		t.Fatalf("second attempt must report a bare 404 with no earlier detail, got:\n%s", out)
+	}
+	if got := site.snapshot(); len(got) != 2 {
+		t.Fatalf("pkg.go.dev requests = %v, want fetch then page", got)
+	}
+}
+
+func TestIndexRelease_MissingOrIncompleteGoModFailsBeforeAnyRequest(t *testing.T) {
+	proxy, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {200}, pagePath: {200}})
+
+	for name, goMod := range map[string][]byte{
+		"missing":        nil,
+		"no module line": []byte("go 1.27\n"),
+	} {
+		script := scriptBeside(t, goMod)
+		code, out := runScript(t, script, proxyURL, siteURL, fast("3"), version)
+		if code != 1 {
+			t.Errorf("%s go.mod: expected exit 1, got %d:\n%s", name, code, out)
+		}
+		if !strings.Contains(out, "could not read the module path from") {
+			t.Errorf("%s go.mod: expected the script's own message, got:\n%s", name, out)
+		}
+		if strings.Contains(out, fmt.Sprintf("awk: can't open")) {
+			t.Errorf("%s go.mod: awk's error must not reach the operator, got:\n%s", name, out)
+		}
+	}
+	if got := proxy.snapshot(); len(got) != 0 {
+		t.Fatalf("proxy must not be contacted without a module path, got %v", got)
+	}
+	if got := site.snapshot(); len(got) != 0 {
+		t.Fatalf("pkg.go.dev must not be contacted without a module path, got %v", got)
 	}
 }

--- a/scripts/index_release_test.go
+++ b/scripts/index_release_test.go
@@ -35,9 +35,15 @@ const (
 // gives up first and reports its own timeout.
 const hangFor = 2 * time.Second
 
+// stallAfterHeaders is a scripted status that makes the recorder send a 200
+// with a body length it then never finishes, so the client sees a status and
+// the transfer still times out.
+const stallAfterHeaders = -1
+
 // recorder is an httptest handler that remembers every request it served and
 // answers each path with a scripted sequence of status codes (the last code
-// repeats once the sequence is exhausted; a 0 holds the request for hangFor).
+// repeats once the sequence is exhausted; a 0 holds the request for hangFor,
+// and stallAfterHeaders sends headers and part of a body, then holds).
 type recorder struct {
 	mu       sync.Mutex
 	requests []string // "METHOD path"
@@ -64,11 +70,23 @@ func (r *recorder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	r.served[req.URL.Path]++
 	status := seq[i]
-	if status == 0 {
+	switch status {
+	case 0:
 		r.mu.Unlock()
 		time.Sleep(hangFor)
 		r.mu.Lock()
 		status = http.StatusOK
+	case stallAfterHeaders:
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		r.mu.Unlock()
+		time.Sleep(hangFor)
+		r.mu.Lock()
+		return
 	}
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(http.StatusText(status)))
@@ -549,5 +567,29 @@ func TestIndexRelease_MissingOrIncompleteGoModFailsBeforeAnyRequest(t *testing.T
 	}
 	if got := site.snapshot(); len(got) != 0 {
 		t.Fatalf("pkg.go.dev must not be contacted without a module path, got %v", got)
+	}
+}
+
+func TestIndexRelease_StalledTransferIsNotARender(t *testing.T) {
+	// pkg.go.dev sends a 200 and part of the page, then stops. The status
+	// arrived but the transfer did not finish within REQUEST_TIMEOUT, and an
+	// unfinished answer is not proof the page renders: the poll reads it as
+	// no status, with curl's timeout, and the run fails rather than passes.
+	_, proxyURL, site, siteURL := stubs(t,
+		map[string][]int{proxyInfoPath: {200}},
+		map[string][]int{fetchPath: {200}, pagePath: {stallAfterHeaders}})
+
+	code, out := run(t, proxyURL, siteURL, polling{attempts: "1", sleep: "0", timeout: "1"}, version)
+	if code != 1 {
+		t.Fatalf("expected exit 1 when the page never finishes, got %d:\n%s", code, out)
+	}
+	if n := site.count("GET " + pagePath); n != 1 {
+		t.Fatalf("page polled %d times, want 1", n)
+	}
+	if !regexp.MustCompile(`attempt 1/1: HTTP 000 \(curl: \(28\) `).MatchString(out) {
+		t.Fatalf("a stalled transfer must be reported as curl's timeout with no status, got:\n%s", out)
+	}
+	if strings.Contains(out, "HTTP 200") {
+		t.Fatalf("a partial 200 must not be reported as a status, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
Closes #70.

## What was wrong

Neither the Go module proxy nor pkg.go.dev watches GitHub. `publish.sh` and `make bump-version` pushed the tag and told the releaser to "wait for pkg.go.dev to index (a few minutes)". Measured 2026-09-10: `v0.26.1`, `v0.26.2` and `v0.26.3` were on GitHub and on `proxy.golang.org` (`@latest` resolved to `v0.26.3`) while the pkg.go.dev versions tab stopped at `v0.26.0` and all three version pages returned 404, three days after the first of those tags. A `POST https://pkg.go.dev/fetch/...@<version>` for each made it appear within seconds.

## What changed

- `scripts/index-release.sh vX.Y.Z`: polls `@v/<version>.info` on the proxy using its case-encoded path (`github.com/eko!d!b/ekodb-client-go`) until 200, POSTs the pkg.go.dev fetch endpoint, then polls the version page until it returns 200. Every request has a connect timeout of 10s and an overall timeout of 30s (`CONNECT_TIMEOUT` / `REQUEST_TIMEOUT`, overridable); the bound is per request, so a polled step can take up to `INDEX_ATTEMPTS x (REQUEST_TIMEOUT + INDEX_SLEEP)`. Exits 1 naming the URL and status (with curl's message when no status was obtained) when the proxy has not served the version after `INDEX_ATTEMPTS` polls, when pkg.go.dev reports it not found, or when the page has not rendered after the same number of polls; exits 2 on a malformed version or on any setting that is not a plain decimal of at most five digits in range (leading zeros rejected, so bash never reads one as octal; a value past 2^63 would otherwise wrap the loop counter) before any request; exits 1 with its own message when `go.mod` is missing or has no `module` line.
- `publish.sh` runs it after `git push origin <tag>`; `make index-release VERSION=vX.Y.Z` runs it alone; the next steps printed by `bump-version` name it.
- `PUBLISHING.md` rewritten to describe the release as it is (this repository, tag on `main`, the index step) instead of a planned move out of a monorepo.

## Evidence

`scripts/index_release_test.go` drives the script against `httptest` stand-ins for both services and asserts the request order, page polling, proxy polling, a proxy 404 (exactly `INDEX_ATTEMPTS` requests, pkg.go.dev untouched), a connection failure (one `000` with curl's message), a fetch 404 (no polling), a transient fetch 5xx (still polls), the poll timeout (exactly `INDEX_ATTEMPTS` requests), the sleep between attempts and its absence after the last, an unresponsive server ending at the request timeout with curl (28), a later attempt carrying no earlier request's detail, a page that sends a 200 and then stalls being read as not rendered, a missing or module-less `go.mod`, and malformed versions or settings including `08` (no requests). The runner has a 20s deadline, so a hang is a red test rather than a stalled package; with the curl timeout flags deleted the timeout test fails in 22s. Red before the script existed, green after.

At `3ae9983` on this branch:

```
make lint   -> 0 issues.
make vet    -> Vet complete!
make build  -> Build complete!
make test   -> ok github.com/ekoDB/ekodb-client-go, ok .../scripts; 463 tests
shellcheck scripts/index-release.sh -> clean
INDEX_ATTEMPTS=2 INDEX_SLEEP=1 make index-release VERSION=v0.26.3
  -> indexed: https://pkg.go.dev/github.com/ekoDB/ekodb-client-go@v0.26.3
make index-release   (no VERSION) -> exit 2
```

The strict proxy encoding was checked against the real proxy: `GET .../github.com/eko!d!b/ekodb-client-go/@v/v0.26.3.info` returns 200 with `Origin.URL` `https://github.com/ekoDB/ekodb-client-go`.

No version bump: the change touches `scripts/`, `Makefile`, `publish.sh` and docs only; nothing importable changes.

<!-- pr-queue: proven 3ae99834ccfe525eaefbf80bc65c726ba508435e -->
